### PR TITLE
test: stabilize supabase-related unit suites

### DIFF
--- a/src/utils/__tests__/errorObservability.test.ts
+++ b/src/utils/__tests__/errorObservability.test.ts
@@ -66,27 +66,20 @@ describe('errorObservability', () => {
 
     it('should capture unhandled promise rejections', () => {
       initErrorObservability();
-      
+
       const rejection = new Error('Unhandled rejection');
-      
-      // jsdom doesn't support PromiseRejectionEvent constructor
-      // So we dispatch a custom event that mimics it
-      const rejectionEvent = {
-        reason: rejection,
-        promise: Promise.reject(rejection),
-      };
-      
-      window.dispatchEvent(new Event('unhandledrejection') as any);
-      
-      // Manually trigger the handler logic
-      const unhandledRejectionHandler = (event: any) => {
-        expect(event.type).toBe('unhandledrejection');
-      };
-      
-      window.addEventListener('unhandledrejection', unhandledRejectionHandler);
-      window.dispatchEvent(new Event('unhandledrejection') as any);
-      
-      expect(errorSpy).toHaveBeenCalled();
+
+      const event = new Event('unhandledrejection');
+      Object.defineProperty(event, 'reason', { value: rejection });
+
+      window.dispatchEvent(event as any);
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        '[ERROR CAPTURE]',
+        expect.objectContaining({
+          message: expect.stringContaining('Unhandled Promise Rejection'),
+        })
+      );
     });
 
     it('should include environment in error logs', () => {

--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { cn } from '../lib/utils';
+import { cn } from '../../lib/utils';
 
 describe('cn (class name utility)', () => {
   it('should merge class names correctly', () => {


### PR DESCRIPTION
## Summary
- refactor the useAuth suite to rely on local supabase stubs, hoisted dependency mocks, and a toggleable supabase enabled flag so the hook can be exercised across token, role, and membership scenarios without module resolution failures
- rebuild the usePasswordSecurity, useSecureFormSubmission, and ensureMembership test suites with self-contained supabase doubles, async-friendly assertions, and expectations that match the production implementations
- refresh supporting test utilities by fixing env variable stubbing, simplifying unhandled rejection simulation, and correcting the cn helper import path

## Testing
- npm test -- --run --reporter=basic

------
https://chatgpt.com/codex/tasks/task_e_6905ad3ed624832ead846ad26ccdfbf1