### PR TITLE
ci: harden e2e csp handling and ios build path

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -12,6 +12,7 @@ jobs:
     timeout-minutes: 45
     env:
       NODE_VERSION: '20'
+      IOS_APP_DIR: ios/App
       WORKSPACE_PATH: App.xcworkspace
       PROJECT_PATH: App.xcodeproj
       SCHEME: App
@@ -34,7 +35,7 @@ jobs:
         run: npx cap sync ios
 
       - name: Ensure Xcode project exists
-        working-directory: ios/App
+        working-directory: ${{ env.IOS_APP_DIR }}
         run: |
           set -euo pipefail
           if [ ! -d "$PROJECT_PATH" ]; then
@@ -47,7 +48,7 @@ jobs:
           fi
 
       - name: Install CocoaPods
-        working-directory: ios/App
+        working-directory: ${{ env.IOS_APP_DIR }}
         run: |
           set -euo pipefail
           if [ ! -f "Podfile" ]; then
@@ -61,7 +62,7 @@ jobs:
           fi
 
       - name: Build iOS workspace
-        working-directory: ios/App
+        working-directory: ${{ env.IOS_APP_DIR }}
         run: |
           set -euo pipefail
           xcodebuild \

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -6,7 +6,7 @@ Dir.chdir(app_ios_dir) unless Dir.pwd == app_ios_dir
 platform :ios, '15.0'
 use_frameworks! linkage: :static
 
-project 'App.xcodeproj'
+project File.join(__dir__, 'App.xcodeproj')
 
 def capacitor_pods
   pod 'Capacitor', :path => '../../node_modules/@capacitor/ios'

--- a/playwright.config.cjs
+++ b/playwright.config.cjs
@@ -1,6 +1,8 @@
 // playwright.config.cjs — CommonJS so GitHub Actions Babel doesn’t choke on `import`
 const { defineConfig, devices } = require('@playwright/test');
 
+const shouldBypassCSP = process.env.PLAYWRIGHT_BYPASS_CSP !== 'false';
+
 module.exports = defineConfig({
   testDir: 'tests',
   fullyParallel: true,
@@ -12,7 +14,7 @@ module.exports = defineConfig({
     baseURL: process.env.BASE_URL || 'http://localhost:5000',
     trace: 'retain-on-failure',
     video: 'retain-on-failure',
-    bypassCSP: true,
+    bypassCSP: shouldBypassCSP,
   },
   projects: [
     { name: 'chromium', use: { ...devices['Desktop Chrome'] } },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,6 +5,11 @@ const baseURL =
   process.env.BASE_URL ||
   'http://localhost:4173';
 
+// Allow CSP bypassing by default so inline scripts/styles used in the app shell
+// don't break headless runs. Teams can opt out by explicitly setting the
+// toggle to "false" when debugging.
+const shouldBypassCSP = process.env.PLAYWRIGHT_BYPASS_CSP !== 'false';
+
 export default defineConfig({
   testDir: './tests',
   fullyParallel: true,
@@ -16,7 +21,7 @@ export default defineConfig({
     baseURL,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
-    bypassCSP: true,
+    bypassCSP: shouldBypassCSP,
   },
   projects: [
     {

--- a/src/utils/__tests__/errorObservability.test.ts
+++ b/src/utils/__tests__/errorObservability.test.ts
@@ -66,27 +66,20 @@ describe('errorObservability', () => {
 
     it('should capture unhandled promise rejections', () => {
       initErrorObservability();
-      
+
       const rejection = new Error('Unhandled rejection');
-      
-      // jsdom doesn't support PromiseRejectionEvent constructor
-      // So we dispatch a custom event that mimics it
-      const rejectionEvent = {
-        reason: rejection,
-        promise: Promise.reject(rejection),
-      };
-      
-      window.dispatchEvent(new Event('unhandledrejection') as any);
-      
-      // Manually trigger the handler logic
-      const unhandledRejectionHandler = (event: any) => {
-        expect(event.type).toBe('unhandledrejection');
-      };
-      
-      window.addEventListener('unhandledrejection', unhandledRejectionHandler);
-      window.dispatchEvent(new Event('unhandledrejection') as any);
-      
-      expect(errorSpy).toHaveBeenCalled();
+
+      const event = new Event('unhandledrejection');
+      Object.defineProperty(event, 'reason', { value: rejection });
+
+      window.dispatchEvent(event as any);
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        '[ERROR CAPTURE]',
+        expect.objectContaining({
+          message: expect.stringContaining('Unhandled Promise Rejection'),
+        })
+      );
     });
 
     it('should include environment in error logs', () => {

--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { cn } from '../lib/utils';
+import { cn } from '../../lib/utils';
 
 describe('cn (class name utility)', () => {
   it('should merge class names correctly', () => {


### PR DESCRIPTION
## Summary
- add an opt-out toggle for Playwright CSP bypassing in both config variants so e2e runs keep working against inline scripts by default
- pin the Podfile to the absolute App.xcodeproj path to avoid "unable to find project" churn during pod install
- DRY the ios/build workflow working directory to an env var so sync → pod install → xcodebuild all operate from ios/App reliably

## Testing
- npm test -- --run --reporter=basic

------
https://chatgpt.com/codex/tasks/task_e_6905ad3ed624832ead846ad26ccdfbf1