### PR TITLE
Harden telephony onboarding & Twilio webhooks

### DIFF
--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -1,8 +1,8 @@
 require_relative '../../node_modules/@capacitor/ios/scripts/pods_helpers'
 
 app_dir = File.expand_path(__dir__)
-if Dir.pwd != app_dir
-  puts "[pods] Switching to #{app_dir} (was #{Dir.pwd})" if ENV['CI']
+unless Dir.pwd == app_dir
+  puts "[pods] Switching to #{app_dir} (was #{Dir.pwd})"
   Dir.chdir(app_dir)
 end
 

--- a/playwright.config.cjs
+++ b/playwright.config.cjs
@@ -1,11 +1,6 @@
 // playwright.config.cjs — CommonJS so GitHub Actions Babel doesn’t choke on `import`
 const { defineConfig, devices } = require('@playwright/test');
 
-// Default to bypassing CSP so inline script/style tags injected during tests do
-// not fail headless runs. Teams can export PLAYWRIGHT_BYPASS_CSP=false locally
-// when debugging strict CSP behaviour.
-const bypassCSP = process.env.PLAYWRIGHT_BYPASS_CSP === 'false' ? false : true;
-
 module.exports = defineConfig({
   testDir: 'tests',
   fullyParallel: true,
@@ -17,7 +12,7 @@ module.exports = defineConfig({
     baseURL: process.env.BASE_URL || 'http://localhost:5000',
     trace: 'retain-on-failure',
     video: 'retain-on-failure',
-    bypassCSP,
+    bypassCSP: true,
   },
   projects: [
     { name: 'chromium', use: { ...devices['Desktop Chrome'] } },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,11 +5,6 @@ const baseURL =
   process.env.BASE_URL ||
   'http://localhost:4173';
 
-// Always bypass CSP in CI/automation so inline scripts/styles used in
-// pre-rendered shells do not break the test harness. Engineers can override by
-// setting PLAYWRIGHT_BYPASS_CSP=false locally when debugging a real CSP issue.
-const bypassCSP = process.env.PLAYWRIGHT_BYPASS_CSP === 'false' ? false : true;
-
 export default defineConfig({
   testDir: './tests',
   fullyParallel: true,
@@ -21,7 +16,7 @@ export default defineConfig({
     baseURL,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
-    bypassCSP,
+    bypassCSP: true,
   },
   projects: [
     {

--- a/src/lib/reportError.ts
+++ b/src/lib/reportError.ts
@@ -1,0 +1,35 @@
+// Lightweight client error bridge to Supabase Edge error intake.
+// Swallows failures so that UI UX is unaffected.
+export async function reportError(err: unknown, orgId?: string) {
+  try {
+    const base = import.meta.env.VITE_FUNCTIONS_BASE;
+    if (!base) return;
+
+    let serialized: Record<string, unknown> = {};
+    try {
+      if (err && typeof err === "object") {
+        serialized = JSON.parse(JSON.stringify(err, Object.getOwnPropertyNames(err)));
+      } else {
+        serialized = { message: String(err) };
+      }
+    } catch (_) {
+      serialized = { message: err instanceof Error ? err.message : String(err) };
+    }
+
+    const payload = {
+      org_id: orgId ?? null,
+      error_id: crypto.randomUUID(),
+      error_type: (err as any)?.type ?? (err instanceof Error ? err.name : "unknown"),
+      payload: serialized,
+      user_agent: navigator.userAgent,
+    };
+
+    await fetch(`${base}/ops-error-intake`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  } catch (_) {
+    // no-op: logging bridge must not throw
+  }
+}

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,4 +1,12 @@
 export const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+  "Access-Control-Allow-Headers": "authorization,content-type,apikey,x-client-info",
 };
+
+export function handleCors(req: Request) {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+  return null;
+}

--- a/supabase/functions/_shared/twilio_sig.ts
+++ b/supabase/functions/_shared/twilio_sig.ts
@@ -1,0 +1,20 @@
+import { validateTwilioSignature as validateSignatureCore } from "./twilioValidator.ts";
+
+export async function validateTwilioSignature(req: Request) {
+  const token = Deno.env.get("TWILIO_AUTH_TOKEN");
+  if (!token) return false;
+
+  const signature = req.headers.get("X-Twilio-Signature") ?? req.headers.get("x-twilio-signature");
+  if (!signature) return false;
+
+  const cloned = req.clone();
+  const text = await cloned.text();
+  const params = new URLSearchParams(text);
+  const payload: Record<string, string> = {};
+  for (const [key, value] of params.entries()) {
+    payload[key] = value;
+  }
+
+  const url = new URL(req.url);
+  return await validateSignatureCore(url.toString(), payload, signature, token);
+}

--- a/supabase/functions/callerid-verify-start/index.ts
+++ b/supabase/functions/callerid-verify-start/index.ts
@@ -1,15 +1,15 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { corsHeaders, handleCors } from "../_shared/cors.ts";
+import { twilioFormPOST } from "../_shared/twilio.ts";
+
 const SID = Deno.env.get("TWILIO_ACCOUNT_SID")!;
 const AUTH = Deno.env.get("TWILIO_AUTH_TOKEN")!;
 const CALLBACK = Deno.env.get("TWILIO_STATUS_CALLBACK_URL")!;
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-};
+
 export default async (req: Request) => {
-  if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: corsHeaders });
-  }
+  const preflight = handleCors(req);
+  if (preflight) return preflight;
+
   try {
     const { phone_number_e164, friendly_name } = await req.json();
     if (!phone_number_e164) {
@@ -18,19 +18,33 @@ export default async (req: Request) => {
         { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } },
       );
     }
+
     const form = new URLSearchParams();
     form.set("PhoneNumber", phone_number_e164);
     if (friendly_name) form.set("FriendlyName", friendly_name);
     form.set("StatusCallback", CALLBACK);
-    const res = await fetch(`https://api.twilio.com/2010-04-01/Accounts/${SID}/OutgoingCallerIds.json`, {
-      method: "POST",
-      headers: { Authorization: "Basic " + btoa(`${SID}:${AUTH}`), "Content-Type": "application/x-www-form-urlencoded" },
-      body: form,
-    });
+
+    const res = await twilioFormPOST(
+      `/Accounts/${SID}/OutgoingCallerIds.json`,
+      form,
+      4,
+      { auth: { accountSid: SID, authToken: AUTH }, headers: { "Idempotency-Key": phone_number_e164 } },
+    );
     const payload = await res.json();
-    if (!res.ok) return new Response(JSON.stringify({ error: payload }), { status: res.status, headers: { ...corsHeaders, "Content-Type": "application/json" } });
-    return new Response(JSON.stringify({ ok: true, data: payload }), { headers: { ...corsHeaders, "Content-Type": "application/json" } });
+    if (!res.ok) {
+      return new Response(JSON.stringify({ error: payload }), {
+        status: res.status,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response(JSON.stringify({ ok: true, data: payload }), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
   } catch (e) {
-    return new Response(JSON.stringify({ error: String(e) }), { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+    return new Response(JSON.stringify({ error: String(e) }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
   }
 };

--- a/supabase/functions/ops-error-intake/index.ts
+++ b/supabase/functions/ops-error-intake/index.ts
@@ -1,0 +1,41 @@
+import { corsHeaders, handleCors } from "../_shared/cors.ts";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const ANON = Deno.env.get("SUPABASE_ANON_KEY")!;
+const SERVICE_ROLE = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+export default async (req: Request) => {
+  const preflight = handleCors(req);
+  if (preflight) return preflight;
+
+  try {
+    const { org_id, error_id, error_type, payload, user_agent } = await req.json();
+
+    const response = await fetch(`${SUPABASE_URL}/rest/v1/error_reports`, {
+      method: "POST",
+      headers: {
+        apikey: ANON,
+        Authorization: `Bearer ${SERVICE_ROLE}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ org_id, error_id, error_type, payload, user_agent }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      return new Response(text, {
+        status: response.status,
+        headers: { ...corsHeaders, "Content-Type": "text/plain" },
+      });
+    }
+
+    return new Response(JSON.stringify({ ok: true }), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    return new Response(JSON.stringify({ ok: false, error: String(error) }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+};

--- a/supabase/functions/ops-health-twilio/index.ts
+++ b/supabase/functions/ops-health-twilio/index.ts
@@ -1,0 +1,15 @@
+import { corsHeaders, handleCors } from "../_shared/cors.ts";
+
+export default async (req: Request) => {
+  const preflight = handleCors(req);
+  if (preflight) return preflight;
+
+  const sid = Boolean(Deno.env.get("TWILIO_ACCOUNT_SID"));
+  const tok = Boolean(Deno.env.get("TWILIO_AUTH_TOKEN"));
+  const ok = sid && tok;
+
+  return new Response(JSON.stringify({ ok, sid, tok }), {
+    status: ok ? 200 : 503,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+};

--- a/supabase/functions/ops-twilio-number-config/index.ts
+++ b/supabase/functions/ops-twilio-number-config/index.ts
@@ -1,0 +1,24 @@
+// deno-lint-ignore-file no-explicit-any
+import { handleCors } from "../_shared/cors.ts";
+import { okHeaders, twilioFormPOST } from "../_shared/twilio.ts";
+
+const ACCOUNT_SID = Deno.env.get("TWILIO_ACCOUNT_SID")!;
+const AUTH_TOKEN = Deno.env.get("TWILIO_AUTH_TOKEN")!;
+
+export default async (req: Request) => {
+  const preflight = handleCors(req);
+  if (preflight) return preflight;
+
+  const { phone_sid, voice_url, voice_method = "POST" } = await req.json();
+
+  const form = new URLSearchParams({ VoiceUrl: voice_url, VoiceMethod: voice_method });
+  const res = await twilioFormPOST(
+    `/Accounts/${ACCOUNT_SID}/IncomingPhoneNumbers/${phone_sid}.json`,
+    form,
+    4,
+    { auth: { accountSid: ACCOUNT_SID, authToken: AUTH_TOKEN } },
+  );
+
+  const payload = await res.text();
+  return new Response(payload, { status: res.status, headers: okHeaders });
+};

--- a/supabase/functions/webcomms-sms-reply/index.ts
+++ b/supabase/functions/webcomms-sms-reply/index.ts
@@ -1,115 +1,92 @@
 // PROMPT D: SMS reply webhook - canonical path
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { createHmac } from "https://deno.land/std@0.168.0/node/crypto.ts";
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
+import { corsHeaders, handleCors } from "../_shared/cors.ts";
+import { validateTwilioSignature } from "../_shared/twilio_sig.ts";
 
 serve(async (req) => {
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders });
-  }
+  const preflight = handleCors(req);
+  if (preflight) return preflight;
 
   try {
-    const twilioAuthToken = Deno.env.get('TWILIO_AUTH_TOKEN');
-    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
-    const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+    const twilioAuthToken = Deno.env.get("TWILIO_AUTH_TOKEN");
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 
     if (!twilioAuthToken) {
-      throw new Error('TWILIO_AUTH_TOKEN not configured');
+      throw new Error("TWILIO_AUTH_TOKEN not configured");
     }
 
-    // Verify Twilio signature (Prompt D)
-    const twilioSignature = req.headers.get('X-Twilio-Signature') || '';
-    const url = `${new URL(req.url).origin}${new URL(req.url).pathname}`;
-    
+    const isValid = await validateTwilioSignature(req);
+    if (!isValid) {
+      console.error("Invalid Twilio signature");
+      return new Response("forbidden", { status: 403, headers: corsHeaders });
+    }
+
     const formData = await req.formData();
     const params: Record<string, string> = {};
     for (const [key, value] of formData.entries()) {
       params[key] = value.toString();
     }
 
-    // Build signature string
-    let dataString = url;
-    Object.keys(params).sort().forEach(key => {
-      dataString += key + params[key];
-    });
-
-    const hmac = createHmac('sha1', twilioAuthToken);
-    hmac.update(dataString);
-    const expectedSignature = hmac.digest('base64');
-
-    if (twilioSignature !== expectedSignature) {
-      console.error('Invalid Twilio signature');
-      return new Response('Forbidden', { status: 403 });
-    }
-
     const messageSid = params.MessageSid || params.SmsSid;
     const from = params.From;
     const to = params.To;
-    const body = params.Body?.trim() || '';
+    const body = params.Body?.trim() || "";
 
-    console.log('SMS received:', { messageSid, from, to, body: body?.substring(0, 50) });
+    console.log("SMS received:", { messageSid, from, to, body: body?.substring(0, 50) });
 
     const supabase = createClient(supabaseUrl, supabaseKey);
 
-    // Upsert event row unique on (source='twilio', external_id=MessageSid) - Prompt D
     const { error: logError } = await supabase
-      .from('sms_reply_logs')
+      .from("sms_reply_logs")
       .upsert({
         message_sid: messageSid,
         from_e164: from,
         to_e164: to,
         body: body,
-        source: 'twilio',
-        external_id: messageSid
+        source: "twilio",
+        external_id: messageSid,
       }, {
-        onConflict: 'source,external_id',
-        ignoreDuplicates: false
+        onConflict: "source,external_id",
+        ignoreDuplicates: false,
       });
 
     if (logError) {
-      console.error('Error logging SMS reply:', logError);
+      console.error("Error logging SMS reply:", logError);
     }
 
-    // Handle opt-out/opt-in keywords
     const bodyUpper = body.toUpperCase();
-    if (['STOP', 'STOPALL', 'UNSUBSCRIBE', 'CANCEL', 'END', 'QUIT'].includes(bodyUpper)) {
-      await supabase.from('consent_logs').insert({
+    if (["STOP", "STOPALL", "UNSUBSCRIBE", "CANCEL", "END", "QUIT"].includes(bodyUpper)) {
+      await supabase.from("consent_logs").insert({
         e164: from,
-        status: 'revoked',
-        channel: 'sms',
-        source: 'keyword_stop'
+        status: "revoked",
+        channel: "sms",
+        source: "keyword_stop",
       });
-    } else if (['START', 'UNSTOP', 'YES'].includes(bodyUpper)) {
-      await supabase.from('consent_logs').insert({
+    } else if (["START", "UNSTOP", "YES"].includes(bodyUpper)) {
+      await supabase.from("consent_logs").insert({
         e164: from,
-        status: 'active',
-        channel: 'sms',
-        source: 'keyword_start'
+        status: "active",
+        channel: "sms",
+        source: "keyword_start",
       });
     }
 
-    // Return TwiML response
-    return new Response('<?xml version="1.0" encoding="UTF-8"?><Response></Response>', {
-      headers: { 
+    return new Response("<?xml version=\"1.0\" encoding=\"UTF-8\"?><Response></Response>", {
+      headers: {
         ...corsHeaders,
-        'Content-Type': 'text/xml' 
-      }
+        "Content-Type": "text/xml",
+      },
     });
-
   } catch (error) {
-    console.error('Error in webcomms-sms-reply:', error);
-    return new Response('<?xml version="1.0" encoding="UTF-8"?><Response></Response>', {
+    console.error("Error in webcomms-sms-reply:", error);
+    return new Response("<?xml version=\"1.0\" encoding=\"UTF-8\"?><Response></Response>", {
       status: 200,
-      headers: { 
+      headers: {
         ...corsHeaders,
-        'Content-Type': 'text/xml' 
-      }
+        "Content-Type": "text/xml",
+      },
     });
   }
 });
-

--- a/supabase/functions/webcomms-sms-status/index.ts
+++ b/supabase/functions/webcomms-sms-status/index.ts
@@ -1,49 +1,32 @@
 // PROMPT D: SMS status callback - canonical path
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { createHmac } from "https://deno.land/std@0.168.0/node/crypto.ts";
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
+import { corsHeaders, handleCors } from "../_shared/cors.ts";
+import { validateTwilioSignature } from "../_shared/twilio_sig.ts";
 
 serve(async (req) => {
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders });
-  }
+  const preflight = handleCors(req);
+  if (preflight) return preflight;
 
   try {
-    const twilioAuthToken = Deno.env.get('TWILIO_AUTH_TOKEN');
-    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
-    const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+    const twilioAuthToken = Deno.env.get("TWILIO_AUTH_TOKEN");
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 
     if (!twilioAuthToken) {
-      throw new Error('TWILIO_AUTH_TOKEN not configured');
+      throw new Error("TWILIO_AUTH_TOKEN not configured");
     }
 
-    // Verify Twilio signature (Prompt D)
-    const twilioSignature = req.headers.get('X-Twilio-Signature') || '';
-    const url = `${new URL(req.url).origin}${new URL(req.url).pathname}`;
-    
+    const isValid = await validateTwilioSignature(req);
+    if (!isValid) {
+      console.error("Invalid Twilio signature");
+      return new Response("Forbidden", { status: 403, headers: corsHeaders });
+    }
+
     const formData = await req.formData();
     const params: Record<string, string> = {};
     for (const [key, value] of formData.entries()) {
       params[key] = value.toString();
-    }
-
-    let dataString = url;
-    Object.keys(params).sort().forEach(key => {
-      dataString += key + params[key];
-    });
-
-    const hmac = createHmac('sha1', twilioAuthToken);
-    hmac.update(dataString);
-    const expectedSignature = hmac.digest('base64');
-
-    if (twilioSignature !== expectedSignature) {
-      console.error('Invalid Twilio signature');
-      return new Response('Forbidden', { status: 403 });
     }
 
     const messageSid = params.MessageSid;
@@ -51,38 +34,35 @@ serve(async (req) => {
     const errorCode = params.ErrorCode;
     const errorMessage = params.ErrorMessage;
 
-    console.log('SMS status update:', { messageSid, messageStatus, errorCode });
+    console.log("SMS status update:", { messageSid, messageStatus, errorCode });
 
     const supabase = createClient(supabaseUrl, supabaseKey);
 
-    // Upsert delivery state by MessageSid (Prompt D)
     const { error } = await supabase
-      .from('sms_status_logs')
+      .from("sms_status_logs")
       .upsert({
         message_sid: messageSid,
         status: messageStatus,
         error_code: errorCode || null,
         error_message: errorMessage || null,
-        updated_at: new Date().toISOString()
+        updated_at: new Date().toISOString(),
       }, {
-        onConflict: 'message_sid',
-        ignoreDuplicates: false
+        onConflict: "message_sid",
+        ignoreDuplicates: false,
       });
 
     if (error) {
-      console.error('Error updating SMS status:', error);
+      console.error("Error updating SMS status:", error);
     }
 
     return new Response(JSON.stringify({ success: true }), {
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
     });
-
   } catch (error) {
-    console.error('Error in webcomms-sms-status:', error);
-    return new Response(JSON.stringify({ error: error.message }), {
+    console.error("Error in webcomms-sms-status:", error);
+    return new Response(JSON.stringify({ error: (error as Error).message }), {
       status: 500,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
     });
   }
 });
-

--- a/supabase/migrations/2025-11-01_error_reports.sql
+++ b/supabase/migrations/2025-11-01_error_reports.sql
@@ -1,0 +1,15 @@
+create extension if not exists pgcrypto;
+create table if not exists public.error_reports (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid,
+  error_id text,
+  error_type text,
+  payload jsonb not null,
+  user_agent text,
+  created_at timestamptz not null default now()
+);
+alter table public.error_reports enable row level security;
+create policy "read own org errors" on public.error_reports
+  for select to authenticated using (org_id is null or auth.jwt() ->> 'org_id' = org_id::text);
+create policy "insert own org errors" on public.error_reports
+  for insert to authenticated with check (org_id is null or auth.jwt() ->> 'org_id' = org_id::text);


### PR DESCRIPTION
## Summary
- add error reports table with RLS and ship edge functions for error intake, Twilio health check, and number reconfiguration
- harden shared Twilio client: centralized CORS helper, form POST wrapper with retries/idempotency, and reusable webhook signature validator
- update onboarding flows, Podfile, and Playwright config so CI installs pods in ios/App, Twilio Calls use the new helper, and CSP is bypassed under test

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69061142e450832e8660dfb3abbee493