### PR TITLE
ci: unblock Playwright CSP and stabilize iOS pods

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -36,9 +36,9 @@ jobs:
 
       - name: Install CocoaPods
         shell: bash
-        working-directory: ${{ env.IOS_APP_DIR }}
         run: |
           set -euo pipefail
+          cd "$IOS_APP_DIR"
 
           echo "Installing pods from $(pwd)"
 
@@ -67,9 +67,9 @@ jobs:
 
       - name: Build iOS workspace
         shell: bash
-        working-directory: ${{ env.IOS_APP_DIR }}
         run: |
           set -euo pipefail
+          cd "$IOS_APP_DIR"
           xcodebuild \
             -workspace "$WORKSPACE_PATH" \
             -scheme "$SCHEME" \

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -43,9 +43,9 @@ jobs:
 
       - name: Install CocoaPods
         shell: bash
-        working-directory: ${{ env.IOS_APP_DIR }}
         run: |
           set -euo pipefail
+          cd "$IOS_APP_DIR"
 
           if [ ! -f Podfile ]; then
             echo "Podfile missing from $(pwd)" >&2

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -6,10 +6,15 @@ unless Dir.pwd == app_dir
   Dir.chdir(app_dir)
 end
 
+app_project_path = File.expand_path('App.xcodeproj', __dir__)
+unless File.directory?(app_project_path)
+  abort "[pods] Expected to find App.xcodeproj at #{app_project_path}. Run `npx cap sync ios` first."
+end
+
 platform :ios, '15.0'
 use_frameworks! linkage: :static
 
-project File.expand_path('App.xcodeproj', __dir__)
+project app_project_path
 
 def capacitor_pods
   pod 'Capacitor', :path => '../../node_modules/@capacitor/ios'

--- a/playwright.config.cjs
+++ b/playwright.config.cjs
@@ -15,6 +15,13 @@ module.exports = defineConfig({
     bypassCSP: true,
   },
   projects: [
-    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        // Keep inline script/style guards functioning during tests
+        bypassCSP: true,
+      },
+    },
   ],
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,7 +21,11 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: {
+        ...devices['Desktop Chrome'],
+        // Explicitly opt out of CSP so inline guards/scripts work under test
+        bypassCSP: true,
+      },
     },
   ],
   webServer: {


### PR DESCRIPTION
## Summary
- explicitly bypass CSP in the Chromium Playwright project so inline guards work during e2e runs
- fail fast in the iOS Podfile when App.xcodeproj is missing to avoid misleading pod install errors
- run CocoaPods install and xcodebuild from ios/App in build/release workflows to ensure the correct project is targeted

## Testing
- npm run test -- --run


------
https://chatgpt.com/codex/tasks/task_e_69090d560b34832ea6265091b092eb4e