### PR TITLE
Fix Playwright CSP bypass and iOS pod install path

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -36,9 +36,9 @@ jobs:
 
       - name: Install CocoaPods
         shell: bash
+        working-directory: ${{ env.IOS_APP_DIR }}
         run: |
           set -euo pipefail
-          cd "$IOS_APP_DIR"
 
           echo "Installing pods from $(pwd)"
 
@@ -67,9 +67,9 @@ jobs:
 
       - name: Build iOS workspace
         shell: bash
+        working-directory: ${{ env.IOS_APP_DIR }}
         run: |
           set -euo pipefail
-          cd "$IOS_APP_DIR"
           xcodebuild \
             -workspace "$WORKSPACE_PATH" \
             -scheme "$SCHEME" \

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -6,9 +6,16 @@ unless Dir.pwd == app_dir
   Dir.chdir(app_dir)
 end
 
-app_project_path = File.expand_path('App.xcodeproj', __dir__)
+project_relative = 'App.xcodeproj'
+app_project_path = File.expand_path(project_relative, __dir__)
+project_file = File.join(app_project_path, 'project.pbxproj')
+
 unless File.directory?(app_project_path)
-  abort "[pods] Expected to find App.xcodeproj at #{app_project_path}. Run `npx cap sync ios` first."
+  abort "[pods] Expected to find #{project_relative} at #{app_project_path}. Run `npx cap sync ios` first."
+end
+
+unless File.exist?(project_file)
+  abort "[pods] Missing project.pbxproj inside #{project_relative}. Re-run `npx cap sync ios`."
 end
 
 platform :ios, '15.0'

--- a/playwright.config.cjs
+++ b/playwright.config.cjs
@@ -1,6 +1,13 @@
 // playwright.config.cjs — CommonJS so GitHub Actions Babel doesn’t choke on `import`
 const { defineConfig, devices } = require('@playwright/test');
 
+const baseUse = {
+  baseURL: process.env.BASE_URL || 'http://localhost:5000',
+  trace: 'retain-on-failure',
+  video: 'retain-on-failure',
+  bypassCSP: true,
+};
+
 module.exports = defineConfig({
   testDir: 'tests',
   fullyParallel: true,
@@ -8,19 +15,13 @@ module.exports = defineConfig({
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: [['list'], ['html', { open: 'never' }]],
-  use: {
-    baseURL: process.env.BASE_URL || 'http://localhost:5000',
-    trace: 'retain-on-failure',
-    video: 'retain-on-failure',
-    bypassCSP: true,
-  },
+  use: baseUse,
   projects: [
     {
       name: 'chromium',
       use: {
         ...devices['Desktop Chrome'],
-        // Keep inline script/style guards functioning during tests
-        bypassCSP: true,
+        ...baseUse,
       },
     },
   ],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,6 +5,13 @@ const baseURL =
   process.env.BASE_URL ||
   'http://localhost:4173';
 
+const baseUse = {
+  baseURL,
+  trace: 'on-first-retry',
+  screenshot: 'only-on-failure',
+  bypassCSP: true,
+} as const;
+
 export default defineConfig({
   testDir: './tests',
   fullyParallel: true,
@@ -12,19 +19,13 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined, // throttle on CI, use all cores locally
   reporter: 'html',
-  use: {
-    baseURL,
-    trace: 'on-first-retry',
-    screenshot: 'only-on-failure',
-    bypassCSP: true,
-  },
+  use: baseUse,
   projects: [
     {
       name: 'chromium',
       use: {
         ...devices['Desktop Chrome'],
-        // Explicitly opt out of CSP so inline guards/scripts work under test
-        bypassCSP: true,
+        ...baseUse,
       },
     },
   ],


### PR DESCRIPTION
## Summary
- share a single base Playwright configuration that forces CSP bypass in both ESM and CJS configs
- harden the Capacitor Podfile checks so pod install fails fast when App.xcodeproj is missing
- update the iOS build workflow to run CocoaPods and xcodebuild from ios/App instead of relying on manual cd

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69093fc4ed1c832ebb1eec65e51c5152