### PR TITLE
fix: adjust accent contrast tokens

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -183,8 +183,8 @@ All colors MUST be HSL.
     --muted: 210 40% 96.1%;
     --muted-foreground: 215.4 16.3% 30%; /* WCAG AA compliant: 5.2:1 contrast ratio (meets 4.5:1 minimum) */
 
-    --accent: var(--brand-orange-light);
-    --accent-foreground: var(--brand-orange-dark);
+    --accent: var(--brand-orange-dark);
+    --accent-foreground: 0 0% 100%;
 
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
@@ -268,7 +268,7 @@ All colors MUST be HSL.
     --muted-foreground: 215 20.2% 65.1%;
 
     --accent: var(--brand-orange-dark);
-    --accent-foreground: var(--brand-orange-light);
+    --accent-foreground: 0 0% 100%;
 
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,7 +2,12 @@ import type { Config } from "tailwindcss";
 
 export default {
   darkMode: ["class"],
-  content: ["./pages/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}", "./app/**/*.{ts,tsx}", "./src/**/*.{ts,tsx}"],
+  content: [
+    "./pages/**/*.{ts,tsx,js,jsx}",
+    "./components/**/*.{ts,tsx,js,jsx}",
+    "./app/**/*.{ts,tsx,js,jsx}",
+    "./src/**/*.{ts,tsx,js,jsx}"
+  ],
   prefix: "",
   theme: {
     container: {


### PR DESCRIPTION
## Summary
- update the accent token pair to use the dark brand orange with white foreground for WCAG AA contrast in light and dark themes
- include JavaScript and JSX files in Tailwind's content glob so the updated classes are generated consistently

## Testing
- npm ci
- npm run build
- npx playwright install --with-deps *(fails: apt repositories return 403 via proxy, browsers not installed)*
- npx playwright test tests/e2e/a11y-smoke.spec.ts *(fails: Playwright browsers missing because install step could not download)*
- npx playwright test *(fails: Playwright browsers missing because install step could not download)*
- npx lhci autorun --config=.lighthouserc.cjs *(fails: Chrome binary not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690dd6436268832d90bb38149243b6cf)