### PR TITLE
fix: improve homepage color contrast

### DIFF
--- a/src/components/sections/BenefitsGrid.tsx
+++ b/src/components/sections/BenefitsGrid.tsx
@@ -29,7 +29,7 @@ export const BenefitsGrid = () => {
           <h2 className="text-2xl md:text-3xl font-bold mb-4">
             The TradeLine 24/7 Difference
           </h2>
-          <p className="text-lg md:text-xl max-w-2xl mx-auto leading-relaxed text-foreground/90">
+          <p className="text-lg md:text-xl max-w-2xl mx-auto leading-relaxed text-foreground">
             Three ways we keep your business moving
           </p>
         </div>
@@ -52,7 +52,7 @@ export const BenefitsGrid = () => {
                   </CardTitle>
                 </CardHeader>
                 <CardContent className="pt-0">
-                  <CardDescription className="text-center leading-relaxed text-base text-foreground/90 group-hover:text-foreground transition-colors duration-300">
+                  <CardDescription className="text-center leading-relaxed text-base text-muted-foreground group-hover:text-foreground transition-colors duration-300">
                     {benefit.description}
                   </CardDescription>
                 </CardContent>

--- a/src/components/sections/HowItWorks.tsx
+++ b/src/components/sections/HowItWorks.tsx
@@ -23,7 +23,7 @@ export const HowItWorks = () => {
           <h2 className="text-3xl md:text-4xl font-bold mb-4">
             How It Works
           </h2>
-          <p className="text-lg text-foreground/90 max-w-2xl mx-auto">
+          <p className="text-lg text-foreground max-w-2xl mx-auto">
             Get up and running in three simple steps
           </p>
         </div>
@@ -40,7 +40,7 @@ export const HowItWorks = () => {
                 <CardTitle className="text-xl">{step.title}</CardTitle>
               </CardHeader>
               <CardContent>
-                <CardDescription className="text-base text-foreground/90">
+                <CardDescription className="text-base text-muted-foreground">
                   {step.description}
                 </CardDescription>
               </CardContent>

--- a/src/components/sections/LeadCaptureCard.tsx
+++ b/src/components/sections/LeadCaptureCard.tsx
@@ -216,7 +216,7 @@ export const LeadCaptureCard = ({ compact = false }: LeadCaptureCardProps) => {
           <h2 className="text-3xl md:text-4xl font-bold mb-4">
             Tell us about your business
           </h2>
-          <p className="text-lg mb-8 text-foreground/90">
+          <p className="text-lg mb-8 text-foreground">
             Start your free trial today.
           </p>
         </>

--- a/src/components/sections/LeadCaptureForm.tsx
+++ b/src/components/sections/LeadCaptureForm.tsx
@@ -212,7 +212,7 @@ export const LeadCaptureForm = () => {
           <h2 className="text-3xl md:text-4xl font-bold mb-4">
             Tell us about your business
           </h2>
-          <p className="text-lg max-w-2xl mx-auto text-foreground/90">
+          <p className="text-lg max-w-2xl mx-auto text-foreground">
             Start your free trial today.
           </p>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -83,16 +83,35 @@ All colors MUST be HSL.
 */
 
 @layer base {
+  html,
+  body {
+    color: hsl(var(--foreground));
+    background: hsl(var(--background));
+  }
+
   body {
     @apply bg-background text-foreground antialiased;
   }
+
   a {
-    color: hsl(var(--brand-orange-dark));
+    color: #1d4ed8;
     text-underline-offset: 2px;
     text-decoration-thickness: 1.5px;
   }
+
+  a:hover {
+    color: #1e40af;
+  }
+
   .dark a {
     color: hsl(var(--brand-orange-light));
+  }
+
+  ::placeholder,
+  input::placeholder,
+  textarea::placeholder {
+    color: hsl(var(--muted-foreground));
+    opacity: 1;
   }
   :root {
     /* Brand Orange Colors from Logo - Primary Brand Color */
@@ -166,7 +185,7 @@ All colors MUST be HSL.
     --overlay-orange: hsl(var(--brand-orange-primary) / 0.30);
 
     --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    --foreground: 222 47% 11%;
 
     --card: 0 0% 100%;
     --card-foreground: 222.2 84% 4.9%;
@@ -181,10 +200,10 @@ All colors MUST be HSL.
     --secondary-foreground: var(--brand-orange-dark);
 
     --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 30%; /* WCAG AA compliant: 5.2:1 contrast ratio (meets 4.5:1 minimum) */
+    --muted-foreground: 215 28% 27%;
 
-    --accent: var(--brand-orange-light);
-    --accent-foreground: var(--brand-orange-dark);
+    --accent: var(--brand-orange-dark);
+    --accent-foreground: 0 0% 100%;
 
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
@@ -268,7 +287,7 @@ All colors MUST be HSL.
     --muted-foreground: 215 20.2% 65.1%;
 
     --accent: var(--brand-orange-dark);
-    --accent-foreground: var(--brand-orange-light);
+    --accent-foreground: 0 0% 100%;
 
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%;
@@ -375,7 +394,7 @@ body.session-warning::before {
 
 /* Fix muted text for better readability in light mode */
 .text-muted-foreground {
-  color: hsl(215.4 16.3% 46%) !important; /* Readable while less aggressive */
+  color: hsl(var(--muted-foreground)) !important;
 }
 
 /* Dark mode: lighter muted text for readability */
@@ -390,14 +409,14 @@ html.dark .text-muted-foreground {
 html:not(.dark) input::placeholder,
 :root:not(.dark) textarea::placeholder,
 html:not(.dark) textarea::placeholder {
-  color: hsl(215.4 16.3% 40%) !important; /* 4.8:1 contrast on white - WCAG AA compliant */
-  opacity: 0.7 !important;
+  color: hsl(var(--muted-foreground)) !important;
+  opacity: 1 !important;
 }
 
 .dark input::placeholder,
 .dark textarea::placeholder {
   color: hsl(215 20.2% 65.1%) !important; /* Readable on dark backgrounds */
-  opacity: 0.7 !important;
+  opacity: 1 !important;
 }
 
 /* Enhanced focus states for better accessibility */

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -50,6 +50,7 @@ const Index = () => {
           backgroundColor: "hsl(0, 0%, 97%)", // Fallback color if image fails (light gray)
         }}
       >
+        <div className="absolute inset-0 bg-black/40 pointer-events-none" aria-hidden="true" />
         {/* Content with translucency - Optimized for performance */}
         <div className="relative z-10" style={{ minHeight: "100vh" }}>
           <AISEOHead

--- a/src/sections/HeroRoiDuo.tsx
+++ b/src/sections/HeroRoiDuo.tsx
@@ -60,15 +60,15 @@ export default function HeroRoiDuo() {
           <h1 id="hero-h1" className="mb-6 bg-gradient-to-r from-primary via-primary/80 to-primary/60 bg-clip-text text-transparent font-extrabold" style={{ fontSize: 'clamp(2rem, 5vw + 1rem, 4.5rem)', lineHeight: '1.1' }} data-lovable-lock="structure-only">
             Your 24/7 Ai Receptionist!
           </h1>
-          <p className="mb-8 max-w-3xl mx-auto font-semibold text-foreground/80" style={{ fontSize: 'clamp(1rem, 2vw + 0.5rem, 2.5rem)', lineHeight: '1.5' }} data-lovable-lock="structure-only">
+          <p className="mb-8 max-w-3xl mx-auto font-semibold text-foreground" style={{ fontSize: 'clamp(1rem, 2vw + 0.5rem, 2.5rem)', lineHeight: '1.5' }} data-lovable-lock="structure-only">
             Never miss a call. Work while you sleep.
           </p>
           <div className="flex flex-wrap justify-center gap-4 mb-8 text-sm md:text-base">
-            <a href="/security" className="text-primary hover:underline font-medium">🔒 Enterprise Security</a>
+            <a href="/security" className="text-[hsl(var(--brand-orange-dark))] hover:underline font-medium">🔒 Enterprise Security</a>
             <span className="text-muted-foreground">•</span>
-            <a href="/compare" className="text-primary hover:underline font-medium">📊 Compare Services</a>
+            <a href="/compare" className="text-[hsl(var(--brand-orange-dark))] hover:underline font-medium">📊 Compare Services</a>
             <span className="text-muted-foreground">•</span>
-            <a href="/pricing" className="text-primary hover:underline font-medium">💰 See Pricing</a>
+            <a href="/pricing" className="text-[hsl(var(--brand-orange-dark))] hover:underline font-medium">💰 See Pricing</a>
           </div>
           
           {/* Premium Phone Number - WCAG AA: fully opaque white, darker orange (7.14:1) */}
@@ -84,7 +84,7 @@ export default function HeroRoiDuo() {
             <span className="text-sm font-semibold uppercase tracking-wide text-[hsl(var(--brand-orange-dark))]/90">FOR DEMO</span>
           </a>
           
-          <h2 className="text-foreground/90 mb-12 mt-16 text-center py-0 font-semibold mx-auto" style={{ fontSize: 'clamp(1.5rem, 3vw + 0.5rem, 2.5rem)' }} data-lovable-lock="structure-only">Help us help you.</h2>
+          <h2 className="text-foreground mb-12 mt-16 text-center py-0 font-semibold mx-auto" style={{ fontSize: 'clamp(1.5rem, 3vw + 0.5rem, 2.5rem)' }} data-lovable-lock="structure-only">Help us help you.</h2>
           
           {/* Custom grid layout for side-by-side components */}
           <div className="hero-roi__container mx-auto" data-lovable-lock="structure-only" aria-label="Start Trial and ROI">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,7 +2,12 @@ import type { Config } from "tailwindcss";
 
 export default {
   darkMode: ["class"],
-  content: ["./pages/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}", "./app/**/*.{ts,tsx}", "./src/**/*.{ts,tsx}"],
+  content: [
+    "./pages/**/*.{ts,tsx,js,jsx}",
+    "./components/**/*.{ts,tsx,js,jsx}",
+    "./app/**/*.{ts,tsx,js,jsx}",
+    "./src/**/*.{ts,tsx,js,jsx}"
+  ],
   prefix: "",
   theme: {
     container: {


### PR DESCRIPTION
## Summary
- enforce baseline foreground, link, and placeholder styles with updated light-theme tokens for contrast compliance
- add a semi-transparent overlay over the home hero background image to preserve text readability
- tighten homepage hero and CTA copy styling so body text uses full foreground tone and anchors use the darker brand orange

## Testing
- npm ci
- npm run build
- npx playwright install --with-deps *(fails: apt repositories blocked by proxy)*
- npx playwright test tests/e2e/a11y-smoke.spec.ts -g "a11y on home" --reporter=list *(fails: Playwright browsers unavailable)*
- npx playwright test *(fails: Playwright browsers unavailable and dependent API checks)
- pnpm lhci autorun --config=.lighthouserc.cjs *(fails: Chrome binary not installed)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690dd6436268832d90bb38149243b6cf)