### PR TITLE
Revert "Fix CI test failures: reportError and AuthLanding (#151)"

### DIFF
--- a/src/lib/__tests__/reportError.fallback.test.ts
+++ b/src/lib/__tests__/reportError.fallback.test.ts
@@ -72,19 +72,10 @@ describe('Report Error - P0 Fix: Silent Error Suppression', () => {
       const testError = 'string error';
       const reportingError = { code: 500, message: 'server error' };
 
-      // Helper to extract message from various error types (matches reportError.ts)
-      const getErrorMessage = (error: unknown): string => {
-        if (error instanceof Error) return error.message;
-        if (error && typeof error === 'object' && 'message' in error) {
-          return String((error as any).message);
-        }
-        return String(error);
-      };
-
       const existing = JSON.parse(localStorage.getItem(fallbackKey) || '[]');
       existing.push({
-        originalError: getErrorMessage(testError),
-        reportingError: getErrorMessage(reportingError),
+        originalError: (testError instanceof Error) ? testError.message : String(testError),
+        reportingError: (reportingError instanceof Error) ? reportingError.message : String(reportingError),
         timestamp: new Date().toISOString(),
         userAgent: 'test-agent'
       });

--- a/src/lib/reportError.ts
+++ b/src/lib/reportError.ts
@@ -34,19 +34,9 @@ export async function reportError(err: unknown, orgId?: string) {
     try {
       const fallbackKey = 'error_reporting_failures';
       const existing = JSON.parse(localStorage.getItem(fallbackKey) || '[]');
-
-      // Helper to extract message from various error types
-      const getErrorMessage = (error: unknown): string => {
-        if (error instanceof Error) return error.message;
-        if (error && typeof error === 'object' && 'message' in error) {
-          return String(error.message);
-        }
-        return String(error);
-      };
-
       existing.push({
-        originalError: getErrorMessage(err),
-        reportingError: getErrorMessage(reportingError),
+        originalError: err instanceof Error ? err.message : String(err),
+        reportingError: reportingError instanceof Error ? reportingError.message : String(reportingError),
         timestamp: new Date().toISOString(),
         userAgent: navigator?.userAgent || 'unknown'
       });

--- a/src/pages/AuthLanding.tsx
+++ b/src/pages/AuthLanding.tsx
@@ -56,7 +56,7 @@ export default function AuthLanding() {
         .from('profiles')
         .select('id')
         .eq('email', email.toLowerCase())
-        .single() as { data: { id: string } | null; error: any };
+        .maybeSingle() as { data: { id: string } | null; error: any };
 
       if (existingUser) {
         setError('An account with this email already exists. Please sign in instead.');


### PR DESCRIPTION
Su

# Objective

Reasoning behind change:Handled all user-requested changes by restructuring the prompt to emphasize inserting debug logging before assertion, stepwise running and re-running, explicit guaranteed fixes, using the shell snippet/grep command, and ensuring overlay and baseline color rules are clearly listed.

Print the exact failing nodes in the a11y test for streamlined debugging of color contrast issues.

# Checklist

Begin with a concise checklist (3-7 bullets) of what you will do; keep items conceptual, not implementation-level:

- Insert debug block to log failing nodes

- Reproduce the accessibility violation

- Isolate and view relevant error output

- Apply fixes for failing elements

- Confirm issue resolution and remove debug code

Reasoning behind change:Checklist items for overlay opacity, baseline color styles, and sweeping homepage offenders were updated to remove '(NEW)' and streamline phrasing, matching the new logical flow requested; now reads as core steps, not additions.

- Ensure overlay at /40 is consistent across hero sections

- Confirm baseline color variables and styles exist in global CSS

- Sweep and fix obvious low-contrast offenders on homepage as flagged by Axe

# Instructions

1. **Add the Debug Block:**

Reasoning behind change:Instructions are made more runbook-like; Step 1 now clearly instructs to insert the debug block before the assertion in the specified file, adopting the requested explicitness and commentary.

Insert this debug block just before the `expect(...)` statement in `tests/e2e/a11y-smoke.spec.ts`:

```typescript

const results = await new AxeBuilder({ page }).analyze();

// DEBUG: Log specific low-contrast nodes for targeted fixes

const cc = results.violations.find(v => v.id === 'color-contrast');

if (cc) {

console.log('--- A11Y color-contrast nodes ---');

for (const n of cc.nodes) {

// Print selector(s) if present, else a trimmed HTML snippet

const sel = n.target?.[0] ?? '';

console.log(sel || n.html?.slice(0, 160) || n.failureSummary || 'node');

}

console.log('--- END nodes ---');

}

```

Reasoning behind change:The assertion is now introduced with 'Then, perform the assertion', directly following the debug block—the order matches the user's required sequence.

Then, perform the assertion:

```typescript

expect(results.violations.find((v) => v.id === 'color-contrast')).toBeFalsy();

```

2. **Run Only the Failing Spec:**

Reasoning behind change:Step 2 with the single failing spec run has clearer instructional language per user request, stating the purpose and expected output for the shell command.

Run just the failing spec to view selectors or snippets that fail the color contrast check. This run will display them in the console.

```shell

npx playwright test tests/e2e/a11y-smoke.spec.ts -g "a11y on home" --reporter=list

```

3. **Apply Minimal, Guaranteed Fixes:**

Reasoning behind change:Minimal fix step (step 3) rewrites prior sections into guaranteed fix checklist using user structure (A: overlay, B: baseline, C: sweep offenders with grep and substitutions).

- **A) Overlay Consistency**: Keep your overlay at `/40` opacity across all hero sections (already done; maintain this).

- **B) Baseline Color Styles**: In your global CSS (e.g., `src/index.css` or Tailwind base layer), make sure the following exists:

```css

@layer base {

:root {

--background: 0 0% 100%;

--foreground: 222 47% 11%; /* ~slate-900 */

--muted-foreground: 215 28% 27%; /* ~slate-700: readable on white */

}

html, body {

color: hsl(var(--foreground));

background: hsl(var(--background));

}

/* placeholders are classic offenders */

::placeholder,

input::placeholder,

textarea::placeholder {

color: hsl(var(--muted-foreground));

opacity: 1;

}

/* links: safe by default on white */

a { color: #1d4ed8; } /* blue-700 */

a:hover { color: #1e40af; }/* blue-800 */

}

```

- **C) Sweep Homepage Offenders**: After running the debug, you may see results such as:

- `text-gray-400`, `text-slate-400` on light sections → change to `text-slate-600`.

- `placeholder:text-gray-400` → `placeholder:text-slate-600`.

- Muted helper text on gradient sections → add `text-slate-700` or wrap with a small `bg-black/40` overlay as done for hero.

To quickly find these offenders:

Reasoning behind change:The grep command and homepage-editing guidance are placed directly after offender examples, with instruction to only edit homepage instances, directly reflecting precise user instructions.

```shell

git grep -nE 'text-(gray|slate|neutral|zinc)-400|placeholder:.*(300|400)' -- src

```

Edit only the instances on the homepage as reported by Axe.

4. **Re-run and Confirm**

Reasoning behind change:Test re-run and confirmation steps are now split into their own explicit instructions, mirroring the user’s sequence, and the 'Expected' outcome is clarified as per the request.

After making fixes, re-run:

```shell

npx playwright test tests/e2e/a11y-smoke.spec.ts -g "a11y on home"

npx playwright test

pnpm lhci autorun --config=.lighthouserc.cjs

```

- Expected: Playwright a11y smoke passes (no color-contrast violation). Lighthouse CI color-contrast assertion passes. Performance warnings may remain, but the job will not fail under threshold.

Reasoning behind change:Summary and validation wording reflect runbook-style: validate failing nodes are surfaced after every fix and rerun as needed, directly mirroring the user’s requested process flow.

After each code edit or test run, validate whether failing nodes are surfaced as expected and if the violation is resolved. If not, verify the debug logic is correctly placed and repeat testing as needed.

# Optional Step: Visual Debugging

To view computed styles for deeper inspection, open the Playwright trace:

```shell

npx playwright show-trace test-results/e2e-a11y-smoke-a11y-on-home-chromium-retry2/trace.zip

```

# Summary

This process quickly identifies and fixes low-contrast accessibility issues by targeting only failing nodes and ensuring a strong base for color contrast.




