### PR TITLE
Improve hero contrast diagnostics and styling

### DIFF
--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -17,6 +17,8 @@ export const HeroSection = () => {
       <div className="absolute inset-0 bg-gradient-to-t from-background/72 via-transparent to-background/67"></div>
       {/* Saturated orange wash (top of background layers) */}
       <div className="absolute inset-0 bg-gradient-to-br from-brand-orange/100 via-brand-orange-light/100 to-brand-orange/89"></div>
+      {/* Unified overlay ensures WCAG contrast */}
+      <div className="absolute inset-0 bg-black/40 pointer-events-none" aria-hidden="true"></div>
       
       {/* Enhanced Glowing Orbs with Animation */}
       <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-brand-orange/40 rounded-full blur-3xl animate-pulse"></div>
@@ -45,7 +47,7 @@ export const HeroSection = () => {
         </h1>
         
         {/* Value Proposition with Delayed Animation */}
-        <p className="text-lg md:text-xl text-foreground/90 mb-8 max-w-2xl mx-auto leading-relaxed animate-fade-in [animation-delay:400ms]">
+        <p className="text-lg md:text-xl text-foreground mb-8 max-w-2xl mx-auto leading-relaxed animate-fade-in [animation-delay:400ms]">
           We pick up when you can't, so customers aren't kept waiting.
         </p>
         

--- a/src/components/sections/PricingHero.tsx
+++ b/src/components/sections/PricingHero.tsx
@@ -2,8 +2,8 @@ import RoiCalculator from "@/components/RoiCalculator";
 import { LeadCaptureCard } from "@/components/sections/LeadCaptureCard";
 import officialLogo from '@/assets/official-logo.png';
 export const PricingHero = () => {
-  return <section className="py-20 bg-gradient-orange-subtle section-heavy">
-      <div className="container">
+  return <section className="relative py-20 bg-gradient-orange-subtle section-heavy overflow-hidden">
+      <div className="container relative z-10">
         {/* Hero Content */}
         <div className="text-center mb-16">
           {/* Logo above hero text */}
@@ -14,11 +14,11 @@ export const PricingHero = () => {
           <h1 id="hero-h1" className="text-4xl md:text-6xl mb-6 bg-gradient-to-r from-primary via-primary/80 to-primary/60 bg-clip-text text-transparent font-extrabold lg:text-7xl">
             Your 24/7 Ai Receptionist!
           </h1>
-          <p className="text-xl mb-8 max-w-3xl mx-auto font-semibold text-foreground/90 md:text-4xl">
+          <p className="text-xl mb-8 max-w-3xl mx-auto font-semibold text-foreground md:text-4xl">
             Never miss a call. Work while you sleep.
           </p>
-          
-          <h2 className="text-2xl font-semibold text-foreground/90 mb-2 mt-[63px] text-center my-0 py-0 md:text-4xl">
+
+          <h2 className="text-2xl font-semibold text-foreground mb-2 mt-[63px] text-center my-0 py-0 md:text-4xl">
             Help us help you
           </h2>
           
@@ -33,5 +33,6 @@ export const PricingHero = () => {
           </div>
         </div>
       </div>
+      <div className="absolute inset-0 bg-black/40 pointer-events-none z-0" aria-hidden="true"></div>
     </section>;
 };

--- a/src/index.css
+++ b/src/index.css
@@ -83,17 +83,6 @@ All colors MUST be HSL.
 */
 
 @layer base {
-  body {
-    @apply bg-background text-foreground antialiased;
-  }
-  a {
-    color: hsl(var(--brand-orange-dark));
-    text-underline-offset: 2px;
-    text-decoration-thickness: 1.5px;
-  }
-  .dark a {
-    color: hsl(var(--brand-orange-light));
-  }
   :root {
     /* Brand Orange Colors from Logo - Primary Brand Color */
     --brand-orange-primary: 21 100% 50%;
@@ -166,7 +155,7 @@ All colors MUST be HSL.
     --overlay-orange: hsl(var(--brand-orange-primary) / 0.30);
 
     --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    --foreground: 222 47% 11%;
 
     --card: 0 0% 100%;
     --card-foreground: 222.2 84% 4.9%;
@@ -181,7 +170,7 @@ All colors MUST be HSL.
     --secondary-foreground: var(--brand-orange-dark);
 
     --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 30%; /* WCAG AA compliant: 5.2:1 contrast ratio (meets 4.5:1 minimum) */
+    --muted-foreground: 215 28% 27%;
 
     --accent: var(--brand-orange-dark);
     --accent-foreground: 0 0% 100%;
@@ -210,6 +199,44 @@ All colors MUST be HSL.
     --sidebar-border: 220 13% 91%;
 
     --sidebar-ring: 217.2 91.2% 59.8%;
+  }
+
+  html,
+  body {
+    color: hsl(var(--foreground));
+    background: hsl(var(--background));
+  }
+
+  body {
+    @apply bg-background text-foreground antialiased;
+  }
+
+  a {
+    color: #1d4ed8;
+    text-underline-offset: 2px;
+    text-decoration-thickness: 1.5px;
+  }
+
+  a:hover {
+    color: #1e40af;
+  }
+
+  .dark a {
+    color: hsl(var(--brand-orange-light));
+  }
+
+  ::placeholder,
+  input::placeholder,
+  textarea::placeholder {
+    color: hsl(var(--muted-foreground));
+    opacity: 1;
+  }
+
+  .dark ::placeholder,
+  .dark input::placeholder,
+  .dark textarea::placeholder {
+    color: hsl(215 20.2% 65.1%);
+    opacity: 1;
   }
 
   .dark {
@@ -384,21 +411,6 @@ html.dark .text-muted-foreground {
 }
 
 /* Green/yellow/blue color fixes removed - use design system tokens instead */
-
-/* CRITICAL: Fix placeholder text contrast - placeholders default to gray-400 (2.4:1) */
-:root:not(.dark) input::placeholder,
-html:not(.dark) input::placeholder,
-:root:not(.dark) textarea::placeholder,
-html:not(.dark) textarea::placeholder {
-  color: hsl(215.4 16.3% 40%) !important; /* 4.8:1 contrast on white - WCAG AA compliant */
-  opacity: 0.7 !important;
-}
-
-.dark input::placeholder,
-.dark textarea::placeholder {
-  color: hsl(215 20.2% 65.1%) !important; /* Readable on dark backgrounds */
-  opacity: 0.7 !important;
-}
 
 /* Enhanced focus states for better accessibility */
 a:focus-visible,

--- a/src/sections/HeroRoiDuo.tsx
+++ b/src/sections/HeroRoiDuo.tsx
@@ -29,13 +29,13 @@ import { LeadCaptureCard } from "../components/sections/LeadCaptureCard";
 import RoiCalculator from "../components/RoiCalculator";
 import officialLogo from '@/assets/official-logo.png';
 export default function HeroRoiDuo() {
-  return <section className="bg-gradient-orange-subtle section-heavy" style={{
+  return <section className="relative bg-gradient-orange-subtle section-heavy overflow-hidden" style={{
     paddingTop: 'max(env(safe-area-inset-top, 0), 5rem)',
     paddingBottom: 'max(env(safe-area-inset-bottom, 0), 5rem)',
     paddingLeft: 'env(safe-area-inset-left, 0)',
     paddingRight: 'env(safe-area-inset-right, 0)'
   }} data-lovable-lock="structure-only">
-      <div className="container" data-lovable-lock="structure-only">
+      <div className="container relative z-10" data-lovable-lock="structure-only">
         {/* Hero Content */}
         <div className="text-center mb-16" data-lovable-lock="structure-only">
           
@@ -60,14 +60,14 @@ export default function HeroRoiDuo() {
           <h1 id="hero-h1" className="mb-6 bg-gradient-to-r from-primary via-primary/80 to-primary/60 bg-clip-text text-transparent font-extrabold" style={{ fontSize: 'clamp(2rem, 5vw + 1rem, 4.5rem)', lineHeight: '1.1' }} data-lovable-lock="structure-only">
             Your 24/7 Ai Receptionist!
           </h1>
-          <p className="mb-8 max-w-3xl mx-auto font-semibold text-foreground/80" style={{ fontSize: 'clamp(1rem, 2vw + 0.5rem, 2.5rem)', lineHeight: '1.5' }} data-lovable-lock="structure-only">
+          <p className="mb-8 max-w-3xl mx-auto font-semibold text-foreground" style={{ fontSize: 'clamp(1rem, 2vw + 0.5rem, 2.5rem)', lineHeight: '1.5' }} data-lovable-lock="structure-only">
             Never miss a call. Work while you sleep.
           </p>
           <div className="flex flex-wrap justify-center gap-4 mb-8 text-sm md:text-base">
             <a href="/security" className="text-primary hover:underline font-medium">🔒 Enterprise Security</a>
-            <span className="text-muted-foreground">•</span>
+            <span className="text-white/70">•</span>
             <a href="/compare" className="text-primary hover:underline font-medium">📊 Compare Services</a>
-            <span className="text-muted-foreground">•</span>
+            <span className="text-white/70">•</span>
             <a href="/pricing" className="text-primary hover:underline font-medium">💰 See Pricing</a>
           </div>
           
@@ -84,7 +84,7 @@ export default function HeroRoiDuo() {
             <span className="text-sm font-semibold uppercase tracking-wide text-[hsl(var(--brand-orange-dark))]/90">FOR DEMO</span>
           </a>
           
-          <h2 className="text-foreground/90 mb-12 mt-16 text-center py-0 font-semibold mx-auto" style={{ fontSize: 'clamp(1.5rem, 3vw + 0.5rem, 2.5rem)' }} data-lovable-lock="structure-only">Help us help you.</h2>
+          <h2 className="text-foreground mb-12 mt-16 text-center py-0 font-semibold mx-auto" style={{ fontSize: 'clamp(1.5rem, 3vw + 0.5rem, 2.5rem)' }} data-lovable-lock="structure-only">Help us help you.</h2>
           
           {/* Custom grid layout for side-by-side components */}
           <div className="hero-roi__container mx-auto" data-lovable-lock="structure-only" aria-label="Start Trial and ROI">
@@ -99,5 +99,6 @@ export default function HeroRoiDuo() {
           </div>
         </div>
       </div>
+      <div className="absolute inset-0 bg-black/40 pointer-events-none z-0" aria-hidden="true"></div>
     </section>;
 }

--- a/tests/e2e/a11y-smoke.spec.ts
+++ b/tests/e2e/a11y-smoke.spec.ts
@@ -4,6 +4,17 @@ import AxeBuilder from '@axe-core/playwright';
 test('a11y on home', async ({ page }) => {
   await page.goto('/');
   const results = await new AxeBuilder({ page }).analyze();
+  // DEBUG: Log specific low-contrast nodes for targeted fixes
+  const cc = results.violations.find(v => v.id === 'color-contrast');
+  if (cc) {
+    console.log('--- A11Y color-contrast nodes ---');
+    for (const n of cc.nodes) {
+      // Print selector(s) if present, else a trimmed HTML snippet
+      const sel = n.target?.[0] ?? '';
+      console.log(sel || n.html?.slice(0, 160) || n.failureSummary || 'node');
+    }
+    console.log('--- END nodes ---');
+  }
   // Color contrast should be fixed - bg-green-700 should pass WCAG AA (4.5:1+)
   expect(results.violations.find((v) => v.id === 'color-contrast')).toBeFalsy();
 });


### PR DESCRIPTION
## Summary
- add targeted logging in the a11y smoke test to print color contrast violations
- normalize hero overlays and copy colors for stronger WCAG contrast across marketing sections
- refresh global foreground, muted, and placeholder tokens to the requested baseline palette

## Testing
- npx playwright test tests/e2e/a11y-smoke.spec.ts -g "a11y on home" --reporter=list *(fails: Playwright browser download blocked in sandbox)*
- pnpm lhci autorun --config=.lighthouserc.cjs *(fails: Chrome installation not available in sandbox)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e1c651bcc832db710b86e4c9bbb96)