### PR TITLE
Implement Jubee narrator control and kid-friendly story view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ const TeamInvite = lazy(() => import("./pages/TeamInvite"));
 const PhoneApps = lazy(() => import("./pages/PhoneApps"));
 const ForwardingWizard = lazy(() => import("./routes/ForwardingWizard"));
 const NotFound = lazy(() => import("./pages/NotFound"));
+const KidsStory = lazy(() => import("./pages/KidsStory"));
 
 const routeEntries: Array<{ path: string; element: React.ReactNode }> = [
   { path: paths.home, element: <Index /> },
@@ -47,6 +48,7 @@ const routeEntries: Array<{ path: string; element: React.ReactNode }> = [
   { path: paths.integrations, element: <Integrations /> },
   { path: paths.phoneApps, element: <PhoneApps /> },
   { path: paths.forwardingWizard, element: <ForwardingWizard /> },
+  { path: paths.kidsStory, element: <KidsStory /> },
   { path: paths.notFound, element: <NotFound /> },
 ];
 

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -6,6 +6,7 @@ import { lazy, Suspense, useEffect, type ReactNode } from "react";
 import { useUserPreferencesStore } from "@/stores/userPreferencesStore";
 import { Toaster } from "@/components/ui/sonner";
 import { useKlaviyoAnalytics } from "@/hooks/useKlaviyoAnalytics";
+import { stopJubeeNarration } from "@/hooks/useJubeeNarrator";
 
 // Lazy load non-critical UI components to reduce initial bundle size
 const MiniChat = lazy(() => import("@/components/ui/MiniChat").then(module => ({ default: module.MiniChat })));
@@ -68,6 +69,12 @@ export const AppLayout = ({ children }: AppLayoutProps) => {
     } else {
       document.body.removeAttribute('data-page');
     }
+  }, [location.pathname]);
+
+  // Stop any ongoing Jubee narration whenever the route changes so
+  // narration never bleeds across screens.
+  useEffect(() => {
+    stopJubeeNarration();
   }, [location.pathname]);
 
   return (

--- a/src/hooks/useJubeeNarrator.ts
+++ b/src/hooks/useJubeeNarrator.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect } from "react";
+
+// Shared singleton controller to prevent overlapping Jubee narration.
+// Keeps the currently active utterance in module scope so every consumer
+// talks to the same speech instance.
+let activeUtterance: SpeechSynthesisUtterance | null = null;
+
+const stopActiveNarration = () => {
+  if (activeUtterance) {
+    window.speechSynthesis.cancel();
+    activeUtterance = null;
+  }
+};
+
+export interface JubeeSpeakOptions {
+  voice?: SpeechSynthesisVoice;
+  rate?: number;
+  pitch?: number;
+  lang?: string;
+}
+
+export const useJubeeNarrator = () => {
+  const stop = useCallback(() => {
+    stopActiveNarration();
+  }, []);
+
+  const speak = useCallback((text: string, options?: JubeeSpeakOptions) => {
+    // Always stop any current narration before starting a new one to avoid overlap.
+    stopActiveNarration();
+
+    const utterance = new SpeechSynthesisUtterance(text);
+
+    if (options?.voice) utterance.voice = options.voice;
+    if (options?.rate) utterance.rate = options.rate;
+    if (options?.pitch) utterance.pitch = options.pitch;
+    if (options?.lang) utterance.lang = options.lang;
+
+    utterance.onend = () => {
+      if (activeUtterance === utterance) {
+        activeUtterance = null;
+      }
+    };
+
+    utterance.onerror = () => {
+      if (activeUtterance === utterance) {
+        activeUtterance = null;
+      }
+    };
+
+    activeUtterance = utterance;
+    window.speechSynthesis.cancel();
+    window.speechSynthesis.speak(utterance);
+  }, []);
+
+  // Clean up any dangling narration when the component using the hook unmounts.
+  useEffect(() => stop, [stop]);
+
+  return { speak, stop } as const;
+};
+
+// Helper for non-hook consumers (e.g., navigation guard) that need to
+// synchronously stop Jubee's narration.
+export const stopJubeeNarration = () => stopActiveNarration();
+

--- a/src/pages/KidsStory.tsx
+++ b/src/pages/KidsStory.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useMemo, useState } from "react";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { useJubeeNarrator } from "@/hooks/useJubeeNarrator";
+
+const storyPages = [
+  "Hi! I'm Jubee, your reading buddy. Let's go on a cozy adventure together!",
+  "We wander through a rainbow forest where every tree hums a gentle tune.",
+  "A friendly cloud swoops low to give us a ride across the cotton-candy sky.",
+  "When the sun yawns, we whisper thank you and glide back home for a hug.",
+];
+
+const JubeeAvatar = () => (
+  <div className="pointer-events-none absolute bottom-4 right-4 z-20">
+    <div className="relative h-28 w-28 rounded-full bg-gradient-to-br from-orange-200 via-pink-200 to-sky-200 shadow-lg shadow-orange-200/60">
+      <div className="absolute inset-2 rounded-full bg-white/70 backdrop-blur-sm border-4 border-white flex items-center justify-center text-2xl font-semibold text-orange-500">
+        Jubee
+      </div>
+    </div>
+  </div>
+);
+
+const PageDots = ({ index }: { index: number }) => (
+  <div className="mt-6 flex justify-center gap-2" aria-label="Story page position">
+    {storyPages.map((_, i) => (
+      <span
+        key={i}
+        className={`h-2 w-2 rounded-full transition-all duration-200 ${
+          i === index ? "bg-orange-500 w-4" : "bg-orange-200"
+        }`}
+      />
+    ))}
+  </div>
+);
+
+const KidsStory = () => {
+  const { speak, stop } = useJubeeNarrator();
+  const [pageIndex, setPageIndex] = useState(0);
+
+  const pageText = useMemo(() => storyPages[pageIndex], [pageIndex]);
+
+  useEffect(() => {
+    speak(pageText, { rate: 1, pitch: 1.05 });
+
+    return () => {
+      stop();
+    };
+  }, [pageText, speak, stop]);
+
+  const goNext = () => setPageIndex(index => Math.min(storyPages.length - 1, index + 1));
+  const goPrev = () => setPageIndex(index => Math.max(0, index - 1));
+
+  return (
+    <div className="relative min-h-screen bg-gradient-to-b from-amber-50 via-pink-50 to-sky-50">
+      <div className="absolute inset-0 pointer-events-none bg-[radial-gradient(circle_at_20%_20%,rgba(255,200,120,0.25),transparent_35%),radial-gradient(circle_at_80%_10%,rgba(120,200,255,0.2),transparent_35%),radial-gradient(circle_at_60%_80%,rgba(255,182,193,0.28),transparent_35%)]" />
+      <div className="relative z-10 mx-auto flex max-w-3xl flex-col gap-6 px-6 py-10">
+        <div className="text-center">
+          <p className="text-sm font-semibold uppercase tracking-wide text-orange-500">Story Time</p>
+          <h1 className="text-3xl font-bold text-rose-500 drop-shadow-sm">Adventure with Jubee</h1>
+        </div>
+
+        <Card className="rounded-3xl border-none bg-white/80 shadow-xl shadow-rose-100/60">
+          <CardContent className="flex flex-col gap-6 p-6">
+            <p className="text-lg leading-relaxed text-rose-800">{pageText}</p>
+
+            <div className="flex justify-between gap-3">
+              <Button variant="secondary" onClick={goPrev} disabled={pageIndex === 0} className="rounded-full px-4">
+                <ArrowLeft className="mr-2 h-4 w-4" /> Back
+              </Button>
+              <Button onClick={goNext} disabled={pageIndex === storyPages.length - 1} className="rounded-full px-4">
+                Next <ArrowRight className="ml-2 h-4 w-4" />
+              </Button>
+            </div>
+
+            <PageDots index={pageIndex} />
+          </CardContent>
+        </Card>
+      </div>
+      <JubeeAvatar />
+    </div>
+  );
+};
+
+export default KidsStory;
+

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -18,5 +18,6 @@ export const paths = {
   phoneApps: "/phone-apps",
   forwardingWizard: "/ops/forwarding",
   voiceSettings: "/ops/voice",
+  kidsStory: "/kids/story",
   notFound: "*",
 } as const;


### PR DESCRIPTION
## Summary
- add a shared Jubee narrator hook that cancels overlapping speech
- stop any ongoing Jubee narration on navigation changes
- introduce a bright kid-facing story page with an overlay Jubee avatar using the shared narrator

## Testing
- npm run typecheck

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691abccb3de0832d8a29e0b99beb4c87)