### PR TITLE
fix: resolve WCAG AA contrast violations on badges

### DIFF
--- a/src/components/sections/HowItWorks.tsx
+++ b/src/components/sections/HowItWorks.tsx
@@ -33,7 +33,7 @@ export const HowItWorks = () => {
             const IconComponent = step.icon;
             return (
             <Card key={index} className="relative text-center group hover:shadow-lg transition-all duration-300">
-              <div className="absolute -top-4 left-1/2 -translate-x-1/2 w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold text-white" style={{ backgroundColor: 'hsl(21 100% 30%)' }}>
+              <div className="absolute -top-4 left-1/2 -translate-x-1/2 w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold text-white" style={{ backgroundColor: 'hsl(21 100% 20%)' }}>
                 {step.step}
               </div>
               <CardHeader className="pt-8">

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -154,7 +154,7 @@ const Pricing = () => {
                   {plans.map((plan, index) => (
                     <Card key={index} id={plan.id} className={`relative ${plan.popular ? 'ring-2 ring-primary shadow-xl scale-105' : ''}`}>
                       {plan.popular && (
-                        <Badge className="absolute -top-3 left-1/2 -translate-x-1/2 bg-primary text-primary-foreground">
+                        <Badge className="absolute -top-3 left-1/2 -translate-x-1/2 text-white" style={{ backgroundColor: 'hsl(21 100% 20%)' }}>
                           <Star className="w-4 h-4 mr-1" />
                           Most Popular
                         </Badge>


### PR DESCRIPTION
Fixed contrast issues on pricing and step badges to meet WCAG 2 AA standards:

- Pricing badge: Changed from bg-primary to hsl(21 100% 20%) with white text
- Step badges: Darkened from hsl(21 100% 30%) to hsl(21 100% 20%)
- Both badges now meet 4.5:1 minimum contrast ratio

Changes:
- src/pages/Pricing.tsx: Updated "Most Popular" badge styling
- src/components/sections/HowItWorks.tsx: Updated step number badges

This resolves accessibility violations while maintaining brand color consistency.

## Changes

<!-- Brief description of what changed -->

## React Hooks Checklist (H310-8)

- [ ] All hooks are at top-level (no conditional/looped hooks)
- [ ] No component function calls (e.g., `Component()` → use `<Component/>`)
- [ ] No early returns before hooks complete
- [ ] ESLint passes with zero hook warnings

## Evidence

## Supabase Auth URL Configuration

- [ ] Site URL set to production domain in Supabase Auth settings
- [ ] Redirect URLs cover magic-link and password-reset flows (HTTPS, no stray trailing slashes)

- [ ] Evidence attached (links to `/ops/twilio-evidence` or test results)
- [ ] Synthetic-smoke passing ([latest run](https://github.com/apex-business-systems/tradeline247/actions/workflows/synthetic-smoke.yml))
- [ ] Twilio Debugger webhook targets `ops-twilio-debugger-intake` (HTTPS)
- [ ] No new secrets in repo (all secrets go to GitHub environments)
- [ ] Store disclosure unchanged or updated (if applicable)

## Testing

<!-- How was this tested? -->

## Deployment Notes

<!-- Any special deployment considerations? -->

---

**For Ops Incidents:** Include CallSid/MessageSid, endpoint, timestamp, and [Twilio Debugger](https://console.twilio.com/us1/monitor/debugger) link.

