### PR TITLE
Adjust hero background responsiveness

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1699,3 +1699,25 @@ button[class*="orange"]:hover:not([class*="outline"]) {
 }
 
 /* ================================================ */
+
+#app-home {
+  background-size: auto, auto, cover;
+  background-position: center, center, center;
+  background-attachment: scroll, scroll, fixed;
+}
+
+@media (max-width: 600px) {
+  #app-home {
+    background-size: auto, auto, contain;
+    background-position: center, center, center top;
+    background-attachment: scroll, scroll, scroll;
+  }
+}
+
+@media (min-width: 601px) and (max-width: 1024px) {
+  #app-home {
+    background-size: auto, auto, cover;
+    background-position: center, center, center top;
+    background-attachment: scroll, scroll, scroll;
+  }
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -52,10 +52,7 @@ const Index = () => {
             ),
             url(${backgroundImage})
           `,
-          backgroundSize: "auto, auto, cover",
-          backgroundPosition: "center, center, center",
           backgroundRepeat: "no-repeat, no-repeat, no-repeat",
-          backgroundAttachment: "scroll, scroll, fixed",
           backgroundColor: "hsl(0, 0%, 97%)", // Fallback color if image fails (light gray)
         }}
       >


### PR DESCRIPTION
Summary
Move all background sizing/position/attachment logic for #app-home into responsive CSS so the hero’s image scales correctly at each breakpoint.
Keep the desktop background exactly as-is while introducing contain + centered positioning on mobile and cover + center-top positioning on tablets.
Remove duplicate inline background sizing props in src/pages/Index.tsx so the new CSS rules take effect without touching layout, content, overlays, or opacity.
Testing
Visual check at ≤600px, 601–1024px, and ≥1024px to confirm:
Mobile uses contain, no cropping/stretching.
Tablet uses cover, centered top.
Desktop remains unchanged (fixed background still applies).
Let me know if you want additional screenshots or automated tests.
