### PR TITLE
fix(ci): move codemagic env blocks to root

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -3,29 +3,33 @@ workflows:
     name: iOS - Capacitor -> TestFlight
     instance_type: mac_mini_m2
     max_build_duration: 60
-    integrations:
-      app_store_connect: Created via API
-    environment:
-      groups:
-        - ios_config
-      ios_signing:
-        distribution_type: app_store
-        bundle_identifier: $BUNDLE_ID
-      vars:
-        APP_VERSION: "1.0.0"
-        APP_BUILD: "1"
-        XCODE_WORKSPACE: "ios/App/App.xcworkspace"
-        XCODE_SCHEME: "App"
-      xcode: latest
-      node: 20.11.1
-      npm: 10
-      cocoapods: default
-    cache:
-      cache_paths:
-        - ~/.npm
-        - ~/.cocoapods
-        - ios/Pods
-    scripts:
+
+integrations:
+  app_store_connect: Created via API
+
+environment:
+  groups:
+    - ios_config
+  ios_signing:
+    distribution_type: app_store
+    bundle_identifier: $BUNDLE_ID
+  vars:
+    APP_VERSION: "1.0.0"
+    APP_BUILD: "1"
+    XCODE_WORKSPACE: "ios/App/App.xcworkspace"
+    XCODE_SCHEME: "App"
+  xcode: latest
+  node: 20.11.1
+  npm: 10
+  cocoapods: default
+
+cache:
+  cache_paths:
+    - ~/.npm
+    - ~/.cocoapods
+    - ios/Pods
+
+scripts:
   - name: Sanitize package.json (remove npm/Capacitor hooks)
     script: |
       node --input-type=module -e "
@@ -202,10 +206,12 @@ workflows:
         -archivePath "$CM_BUILD_DIR/TradeLine247.xcarchive" \
         -exportOptionsPlist exportOptions.plist \
         -exportPath "$CM_BUILD_DIR/export"
-    artifacts:
-      - $CM_BUILD_DIR/export/*.ipa
-      - $CM_BUILD_DIR/TradeLine247.xcarchive
-    publishing:
-      app_store_connect:
-        auth: integration
-        submit_to_testflight: true
+
+artifacts:
+  - $CM_BUILD_DIR/export/*.ipa
+  - $CM_BUILD_DIR/TradeLine247.xcarchive
+
+publishing:
+  app_store_connect:
+    auth: integration
+    submit_to_testflight: true


### PR DESCRIPTION
## Changes

<!-- Brief description of what changed -->

## React Hooks Checklist (H310-8)

- [ ] All hooks are at top-level (no conditional/looped hooks)
- [ ] No component function calls (e.g., `Component()` → use `<Component/>`)
- [ ] No early returns before hooks complete
- [ ] ESLint passes with zero hook warnings

## Evidence

## Supabase Auth URL Configuration

- [ ] Site URL set to production domain in Supabase Auth settings
- [ ] Redirect URLs cover magic-link and password-reset flows (HTTPS, no stray trailing slashes)

- [ ] Evidence attached (links to `/ops/twilio-evidence` or test results)
- [ ] Synthetic-smoke passing ([latest run](https://github.com/apex-business-systems/tradeline247/actions/workflows/synthetic-smoke.yml))
- [ ] Twilio Debugger webhook targets `ops-twilio-debugger-intake` (HTTPS)
- [ ] No new secrets in repo (all secrets go to GitHub environments)
- [ ] Store disclosure unchanged or updated (if applicable)

## Testing

<!-- How was this tested? -->

## Deployment Notes

<!-- Any special deployment considerations? -->

---

**For Ops Incidents:** Include CallSid/MessageSid, endpoint, timestamp, and [Twilio Debugger](https://console.twilio.com/us1/monitor/debugger) link.

