### PR TITLE
fix(ios): Manual signing with explicit provisioning profile

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -369,7 +369,7 @@
 			baseConfigurationReference = AF51FD2D460BCFE21FA515B2 /* Pods-App.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = NWGUYF42KW;
@@ -377,8 +377,8 @@
                                 IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.0;
-				PROVISIONING_PROFILE_SPECIFIER = TL247_mobpro_tradeline_01;
 				PRODUCT_BUNDLE_IDENTIFIER = com.apex.tradeline;
+				PROVISIONING_PROFILE_SPECIFIER = TL247_mobpro_tradeline_01;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
COMPLETE FIX for exit code 65 and 70 failures:

project.pbxproj Release config:
- Set CODE_SIGN_IDENTITY="Apple Distribution" (was "iPhone Distribution")
- Set CODE_SIGN_STYLE=Manual (already configured)
- Set DEVELOPMENT_TEAM=NWGUYF42KW (already configured)
- Set PROVISIONING_PROFILE_SPECIFIER=TL247_mobpro_tradeline_01 (already configured)
- Set PRODUCT_BUNDLE_IDENTIFIER=com.apex.tradeline (already configured)

scripts/build-ios.sh:
- Add CODE_SIGN_STYLE=Manual to xcodebuild archive command
- Add CODE_SIGN_IDENTITY="Apple Distribution" to xcodebuild archive command
- Add PROVISIONING_PROFILE_SPECIFIER to xcodebuild archive command
- Add DEVELOPMENT_TEAM and PRODUCT_BUNDLE_IDENTIFIER
- Add proper exit code 65 for archive failures
- Add proper exit code 70 for export failures
- Update ExportOptions.plist to use app-store method (not app-store-connect)
- Use hardcoded values in ExportOptions.plist with HEREDOC

This ensures both:
1. Project configuration has Manual signing permanently configured
2. Build command explicitly passes all signing parameters
3. Proper error codes for debugging Codemagic failures

Fixes:
- Exit code 65: "App requires a provisioning profile"
- Exit code 70: Export account/signing failures

## Changes

<!-- Brief description of what changed -->

## React Hooks Checklist (H310-8)

- [ ] All hooks are at top-level (no conditional/looped hooks)
- [ ] No component function calls (e.g., `Component()` → use `<Component/>`)
- [ ] No early returns before hooks complete
- [ ] ESLint passes with zero hook warnings

## Evidence

## Supabase Auth URL Configuration

- [ ] Site URL set to production domain in Supabase Auth settings
- [ ] Redirect URLs cover magic-link and password-reset flows (HTTPS, no stray trailing slashes)

- [ ] Evidence attached (links to `/ops/twilio-evidence` or test results)
- [ ] Synthetic-smoke passing ([latest run](https://github.com/apex-business-systems/tradeline247/actions/workflows/synthetic-smoke.yml))
- [ ] Twilio Debugger webhook targets `ops-twilio-debugger-intake` (HTTPS)
- [ ] No new secrets in repo (all secrets go to GitHub environments)
- [ ] Store disclosure unchanged or updated (if applicable)

## Testing

<!-- How was this tested? -->

## Deployment Notes

<!-- Any special deployment considerations? -->

---

**For Ops Incidents:** Include CallSid/MessageSid, endpoint, timestamp, and [Twilio Debugger](https://console.twilio.com/us1/monitor/debugger) link.

