### PR TITLE
fix(fastlane): correct ASC API key authentication

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -9,39 +9,19 @@
 default_platform(:ios)
 
 platform :ios do
-  # =============================================================================
-  # Initialize App Store Connect API key using environment variables provided by Codemagic
-  # =============================================================================
-  # The API key is initialized at the platform level (outside lane definitions)
-  # to ensure it's available to all lanes and follows Fastlane best practices
-  # for credential management. All secrets are read from Codemagic environment
-  # variables (ios_config or appstore_credentials group).
-  # =============================================================================
-  api_key = app_store_connect_api_key(
-    key_id:      ENV["APP_STORE_CONNECT_KEY_IDENTIFIER"], # Codemagic: .env or variable group
-    issuer_id:   ENV["APP_STORE_CONNECT_ISSUER_ID"],     # Codemagic: .env or variable group
-    key_content: ENV["APP_STORE_CONNECT_PRIVATE_KEY"]     # Codemagic: .env or variable group. Use key_filepath only if referencing a local file.
-  )
-
-  # =============================================================================
-  # Upload lane for TestFlight using the API key and .ipa path provided by CI
-  # =============================================================================
-  # This lane uploads the IPA built by the CI/CD pipeline to TestFlight.
-  # The IPA path is set by build-ios.sh and exported as IPA_PATH environment variable.
-  # Only essential parameters (api_key and ipa) are used to ensure compatibility
-  # with latest Fastlane versions and minimize potential errors.
-  # =============================================================================
-  desc "Upload IPA to TestFlight (CI/CD pipeline)"
   lane :upload do
+    api_key = app_store_connect_api_key(
+      key_id: ENV.fetch("APP_STORE_CONNECT_KEY_IDENTIFIER"),
+      issuer_id: ENV.fetch("APP_STORE_CONNECT_ISSUER_ID"),
+      key_content: ENV.fetch("APP_STORE_CONNECT_PRIVATE_KEY"),
+      is_key_content_base64: false,
+      in_house: false
+    )
+
     upload_to_testflight(
-      api_key: api_key,               # Authenticates with App Store Connect using the API key initialized above
-      ipa: ENV["IPA_PATH"]            # Path to IPA built in CI/CD pipeline (set by build-ios.sh)
-      # Optional parameters (uncomment as needed):
-      # skip_submission: true,                    # Skip automatic submission to App Store review
-      # skip_waiting_for_build_processing: true, # Don't wait for build processing to complete (faster CI)
-      # groups: ["Internal Testers"],             # Specific TestFlight groups to notify
-      # notify_external_testers: false,           # Don't notify external testers automatically
-      # changelog: "CI build from #{ENV['CM_COMMIT']}" # Build changelog message
+      api_key: api_key,
+      ipa: ENV.fetch("IPA_PATH"),
+      skip_waiting_for_build_processing: true
     )
   end
 end

--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -202,6 +202,15 @@ if [[ -z "$IPA_PATH" || ! -f "$IPA_PATH" ]]; then
   exit 70
 fi
 
+# Export IPA_PATH for Fastlane (ensure IPA is at expected location)
+if [[ -n "${CM_BUILD_DIR:-}" ]]; then
+  mkdir -p "$CM_BUILD_DIR/ipa"
+  cp "$IPA_PATH" "$CM_BUILD_DIR/ipa/App.ipa"
+  export IPA_PATH="$CM_BUILD_DIR/ipa/App.ipa"
+else
+  export IPA_PATH="$IPA_PATH"
+fi
+
 echo ""
 echo "=============================================="
 echo "✅ BUILD SUCCESSFUL"


### PR DESCRIPTION
- Use ENV.fetch() for fail-fast error handling
- Add is_key_content_base64: false to API key initialization
- Move API key initialization inside lane (better error handling)
- Export IPA_PATH to CM_BUILD_DIR/ipa/App.ipa for Fastlane
- Add skip_waiting_for_build_processing for faster CI

## Changes

<!-- Brief description of what changed -->

## React Hooks Checklist (H310-8)

- [ ] All hooks are at top-level (no conditional/looped hooks)
- [ ] No component function calls (e.g., `Component()` → use `<Component/>`)
- [ ] No early returns before hooks complete
- [ ] ESLint passes with zero hook warnings

## Evidence

## Supabase Auth URL Configuration

- [ ] Site URL set to production domain in Supabase Auth settings
- [ ] Redirect URLs cover magic-link and password-reset flows (HTTPS, no stray trailing slashes)

- [ ] Evidence attached (links to `/ops/twilio-evidence` or test results)
- [ ] Synthetic-smoke passing ([latest run](https://github.com/apex-business-systems/tradeline247/actions/workflows/synthetic-smoke.yml))
- [ ] Twilio Debugger webhook targets `ops-twilio-debugger-intake` (HTTPS)
- [ ] No new secrets in repo (all secrets go to GitHub environments)
- [ ] Store disclosure unchanged or updated (if applicable)

## Testing

<!-- How was this tested? -->

## Deployment Notes

<!-- Any special deployment considerations? -->

---

**For Ops Incidents:** Include CallSid/MessageSid, endpoint, timestamp, and [Twilio Debugger](https://console.twilio.com/us1/monitor/debugger) link.

