### PR TITLE
Restore env-based App Store Connect auth in Codemagic

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -21,14 +21,10 @@ workflows:
       cache_paths:
         - ~/.npm
         - ~/.cocoapods
-        -       ios/Pods
+        - ios/Pods
     scripts:
       - name: Install dependencies
         script: npm ci
-      - name: Install Fastlane
-        script: |
-          gem install bundler
-          bundle install
       - name: Quality gates
         script: npm run lint && npm run typecheck && npm run test:unit
       - name: Playwright smoke
@@ -37,50 +33,8 @@ workflows:
           npm run test:e2e:smoke
       - name: Build archive & IPA
         script: bash scripts/build-ios.sh
-      - name: Write ASC API Key to file
-        script: |
-          set -euo pipefail
-          
-          # PRIORITY 3: Validate environment variable exists
-          if [ -z "${APP_STORE_CONNECT_PRIVATE_KEY:-}" ] && [ -z "${APP_STORE_CONNECT_API_KEY:-}" ] && [ -z "${ASC_API_KEY:-}" ]; then
-            echo "❌ ERROR: API key not found. Checked: APP_STORE_CONNECT_PRIVATE_KEY, APP_STORE_CONNECT_API_KEY, ASC_API_KEY"
-            exit 1
-          fi
-          
-          # Use first available variable (fallback chain)
-          KEY_CONTENT="${APP_STORE_CONNECT_PRIVATE_KEY:-${APP_STORE_CONNECT_API_KEY:-${ASC_API_KEY}}}"
-          
-          # Write to CM_BUILD_DIR first (persists across steps)
-          KEY_FILE="${CM_BUILD_DIR:-/tmp}/AuthKey.p8"
-          echo "$KEY_CONTENT" > "$KEY_FILE"
-          chmod 600 "$KEY_FILE"
-          
-          # Validate key format
-          if ! grep -q "BEGIN PRIVATE KEY" "$KEY_FILE" || ! grep -q "END PRIVATE KEY" "$KEY_FILE"; then
-            echo "❌ ERROR: API key has invalid format (missing BEGIN/END markers)"
-            exit 1
-          fi
-          
-          echo "✅ API key written to $KEY_FILE"
-          # Debug: verify key format (first/last lines only)
-          head -1 "$KEY_FILE"
-          tail -1 "$KEY_FILE"
-          
-          # Also write to /tmp for Fastlane (both locations for reliability)
-          cp "$KEY_FILE" /tmp/AuthKey.p8
-          chmod 600 /tmp/AuthKey.p8
-          echo "✅ API key also copied to /tmp/AuthKey.p8"
-          
-          # Debug: show which env var was used
-          if [ -n "${APP_STORE_CONNECT_PRIVATE_KEY:-}" ]; then
-            echo "📝 Using: APP_STORE_CONNECT_PRIVATE_KEY"
-          elif [ -n "${APP_STORE_CONNECT_API_KEY:-}" ]; then
-            echo "📝 Using: APP_STORE_CONNECT_API_KEY"
-          else
-            echo "📝 Using: ASC_API_KEY"
-          fi
       - name: Upload to TestFlight
-        script: bundle exec fastlane ios upload
+        script: fastlane ios upload
       - name: Verify artifacts
         script: bash scripts/verify-codemagic.sh
     artifacts:

--- a/docs/CODEMAGIC_IOS_BUILD_GUIDE.md
+++ b/docs/CODEMAGIC_IOS_BUILD_GUIDE.md
@@ -92,6 +92,11 @@ After successful build, download these artifacts from Codemagic:
 ### **Option 1: Automatic (via Codemagic)**
 Workflow includes `fastlane ios upload` step which automatically uploads to TestFlight.
 
+**Fastlane lane + auth expectations**
+- Lane invoked: `ios upload` from `fastlane/Fastfile`.
+- Authentication: `app_store_connect_api_key` reads existing Codemagic secrets `APP_STORE_CONNECT_KEY_IDENTIFIER`, `APP_STORE_CONNECT_ISSUER_ID`, and `APP_STORE_CONNECT_PRIVATE_KEY` (raw .p8 contents—no file writing required).
+- IPA location: `scripts/build-ios.sh` exports `IPA_PATH` (or writes `ipa_path.txt`) that Fastlane consumes directly.
+
 ### **Option 2: Manual (from Windows PC)**
 
 1. **Download .ipa** from Codemagic artifacts

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,57 +10,11 @@ default_platform(:ios)
 
 platform :ios do
   lane :upload do
-    # PRIORITY 2: Check CM_BUILD_DIR first, fallback to /tmp
-    key_filepath = if ENV["CM_BUILD_DIR"] && File.exist?(File.join(ENV["CM_BUILD_DIR"], "AuthKey.p8"))
-      File.join(ENV["CM_BUILD_DIR"], "AuthKey.p8")
-    elsif File.exist?("/tmp/AuthKey.p8")
-      "/tmp/AuthKey.p8"
-    else
-      nil
-    end
-    
-    unless key_filepath && File.exist?(key_filepath)
-      UI.user_error!("❌ API key file not found. Checked: #{ENV["CM_BUILD_DIR"]}/AuthKey.p8, /tmp/AuthKey.p8. Ensure 'Write ASC API Key to file' step ran successfully.")
-    end
-    
-    unless File.readable?(key_filepath)
-      UI.user_error!("❌ API key file not readable: #{key_filepath}. Check file permissions.")
-    end
-    
-    # Verify key format (should start with BEGIN PRIVATE KEY)
-    key_content = File.read(key_filepath)
-    unless key_content.include?("BEGIN PRIVATE KEY") && key_content.include?("END PRIVATE KEY")
-      UI.user_error!("❌ API key file has invalid format. Expected BEGIN/END PRIVATE KEY markers.")
-    end
-    
-    UI.message("✅ API key file validated: #{key_filepath} (#{key_content.lines.count} lines)")
-    
-    # PRIORITY 1: Variable name fallbacks (handle different Codemagic formats)
-    key_id = ENV["APP_STORE_CONNECT_KEY_IDENTIFIER"] ||
-             ENV["APP_STORE_CONNECT_API_KEY_ID"] ||
-             ENV["ASC_API_KEY_ID"] ||
-             ENV["APP_STORE_CONNECT_KEY_ID"]
-    
-    issuer_id = ENV["APP_STORE_CONNECT_ISSUER_ID"] ||
-                ENV["APP_STORE_CONNECT_API_KEY_ISSUER_ID"] ||
-                ENV["ASC_API_ISSUER_ID"] ||
-                ENV["APP_STORE_CONNECT_ISSUER"]
-    
-    if key_id.nil? || key_id.empty?
-      UI.user_error!("❌ Key ID not found. Checked: APP_STORE_CONNECT_KEY_IDENTIFIER, APP_STORE_CONNECT_API_KEY_ID, ASC_API_KEY_ID, APP_STORE_CONNECT_KEY_ID")
-    end
-    
-    if issuer_id.nil? || issuer_id.empty?
-      UI.user_error!("❌ Issuer ID not found. Checked: APP_STORE_CONNECT_ISSUER_ID, APP_STORE_CONNECT_API_KEY_ISSUER_ID, ASC_API_ISSUER_ID, APP_STORE_CONNECT_ISSUER")
-    end
-    
-    UI.message("🔑 Key ID: #{key_id}")
-    UI.message("🔑 Issuer ID: #{issuer_id}")
-    
     api_key = app_store_connect_api_key(
-      key_id: key_id,
-      issuer_id: issuer_id,
-      key_filepath: key_filepath,
+      key_id: ENV.fetch("APP_STORE_CONNECT_KEY_IDENTIFIER"),
+      issuer_id: ENV.fetch("APP_STORE_CONNECT_ISSUER_ID"),
+      key_content: ENV.fetch("APP_STORE_CONNECT_PRIVATE_KEY"),
+      is_key_content_base64: false,
       in_house: false
     )
 


### PR DESCRIPTION
## Summary
- Revert the iOS `upload` lane to use the existing `APP_STORE_CONNECT_*` environment variables via `key_content`, matching the last known good authentication flow.
- Simplify the Codemagic TestFlight workflow by removing ad-hoc API key file creation/fastlane installation and restoring the original cache path indentation and upload command.
- Document the expected Fastlane lane, authentication variables, and IPA path handoff in the Codemagic iOS build guide.

## Testing
- ⚠️ `bundle exec fastlane lanes --platform ios` *(fails locally because fastlane/CFPropertyList depends on `kconv` with Ruby 3.4; lane definitions remain intact).*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6922104fe3e0832dbdce8dd7b54a4d3c)