### PR TITLE
Fix TestFlight upload authentication

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,58 +10,18 @@ default_platform(:ios)
 
 platform :ios do
   lane :upload do
-    # PRIORITY 2: Check CM_BUILD_DIR first, fallback to /tmp
-    key_filepath = if ENV["CM_BUILD_DIR"] && File.exist?(File.join(ENV["CM_BUILD_DIR"], "AuthKey.p8"))
-      File.join(ENV["CM_BUILD_DIR"], "AuthKey.p8")
-    elsif File.exist?("/tmp/AuthKey.p8")
-      "/tmp/AuthKey.p8"
-    else
-      nil
-    end
-    
-    unless key_filepath && File.exist?(key_filepath)
-      UI.user_error!("❌ API key file not found. Checked: #{ENV["CM_BUILD_DIR"]}/AuthKey.p8, /tmp/AuthKey.p8. Ensure 'Write ASC API Key to file' step ran successfully.")
-    end
-    
-    unless File.readable?(key_filepath)
-      UI.user_error!("❌ API key file not readable: #{key_filepath}. Check file permissions.")
-    end
-    
-    # Verify key format (should start with BEGIN PRIVATE KEY)
-    key_content = File.read(key_filepath)
-    unless key_content.include?("BEGIN PRIVATE KEY") && key_content.include?("END PRIVATE KEY")
-      UI.user_error!("❌ API key file has invalid format. Expected BEGIN/END PRIVATE KEY markers.")
-    end
-    
-    UI.message("✅ API key file validated: #{key_filepath} (#{key_content.lines.count} lines)")
-    
-    # PRIORITY 1: Variable name fallbacks (handle different Codemagic formats)
-    key_id = ENV["APP_STORE_CONNECT_KEY_IDENTIFIER"] ||
-             ENV["APP_STORE_CONNECT_API_KEY_ID"] ||
-             ENV["ASC_API_KEY_ID"] ||
-             ENV["APP_STORE_CONNECT_KEY_ID"]
-    
-    issuer_id = ENV["APP_STORE_CONNECT_ISSUER_ID"] ||
-                ENV["APP_STORE_CONNECT_API_KEY_ISSUER_ID"] ||
-                ENV["ASC_API_ISSUER_ID"] ||
-                ENV["APP_STORE_CONNECT_ISSUER"]
-    
-    if key_id.nil? || key_id.empty?
-      UI.user_error!("❌ Key ID not found. Checked: APP_STORE_CONNECT_KEY_IDENTIFIER, APP_STORE_CONNECT_API_KEY_ID, ASC_API_KEY_ID, APP_STORE_CONNECT_KEY_ID")
-    end
-    
-    if issuer_id.nil? || issuer_id.empty?
-      UI.user_error!("❌ Issuer ID not found. Checked: APP_STORE_CONNECT_ISSUER_ID, APP_STORE_CONNECT_API_KEY_ISSUER_ID, ASC_API_ISSUER_ID, APP_STORE_CONNECT_ISSUER")
-    end
-    
+    # Get API key components directly from environment variables
+    issuer_id = ENV.fetch("APP_STORE_CONNECT_ISSUER_ID")
+    key_id = ENV.fetch("APP_STORE_ID")
+    key = ENV.fetch("APP_STORE_CONNECT_PRIVATE_KEY")
+
     UI.message("🔑 Key ID: #{key_id}")
     UI.message("🔑 Issuer ID: #{issuer_id}")
-    
+
     api_key = app_store_connect_api_key(
-      key_id: key_id,
       issuer_id: issuer_id,
-      key_filepath: key_filepath,
-      in_house: false
+      key_id: key_id,
+      key: key
     )
 
     # Get IPA_PATH from environment or file (Codemagic script steps are isolated)


### PR DESCRIPTION
- Correct App Store Connect API key mapping to use proper env vars
- Use APP_STORE_ID for key_id instead of misconfigured APP_STORE_CONNECT_KEY_IDENTIFIER
- Use APP_STORE_CONNECT_PRIVATE_KEY directly instead of file-based approach
- issuer_id â† APP_STORE_CONNECT_ISSUER_ID
- key_id â† APP_STORE_ID
- key â† APP_STORE_CONNECT_PRIVATE_KEY

## Changes

<!-- Brief description of what changed -->

## React Hooks Checklist (H310-8)

- [ ] All hooks are at top-level (no conditional/looped hooks)
- [ ] No component function calls (e.g., `Component()` → use `<Component/>`)
- [ ] No early returns before hooks complete
- [ ] ESLint passes with zero hook warnings

## Evidence

## Supabase Auth URL Configuration

- [ ] Site URL set to production domain in Supabase Auth settings
- [ ] Redirect URLs cover magic-link and password-reset flows (HTTPS, no stray trailing slashes)

- [ ] Evidence attached (links to `/ops/twilio-evidence` or test results)
- [ ] Synthetic-smoke passing ([latest run](https://github.com/apex-business-systems/tradeline247/actions/workflows/synthetic-smoke.yml))
- [ ] Twilio Debugger webhook targets `ops-twilio-debugger-intake` (HTTPS)
- [ ] No new secrets in repo (all secrets go to GitHub environments)
- [ ] Store disclosure unchanged or updated (if applicable)

## Testing

<!-- How was this tested? -->

## Deployment Notes

<!-- Any special deployment considerations? -->

---

**For Ops Incidents:** Include CallSid/MessageSid, endpoint, timestamp, and [Twilio Debugger](https://console.twilio.com/us1/monitor/debugger) link.

