### PR TITLE
fix: enterprise-grade iOS build script for production deployment

### DIFF
--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -11,11 +11,6 @@ EXPORT_OPTIONS_PLIST="${EXPORT_OPTIONS_PLIST:-ios/ExportOptions.plist}"
 ARCHIVE_PATH="${ARCHIVE_PATH:-ios/build/TradeLine247.xcarchive}"
 EXPORT_PATH="${EXPORT_PATH:-ios/build/export}"
 
-if [[ ! -f "ios/${XCODE_WORKSPACE}" ]]; then
-  echo "❌ Xcode workspace ios/${XCODE_WORKSPACE} not found" >&2
-  exit 1
-fi
-
 if [[ ! -f "$EXPORT_OPTIONS_PLIST" ]]; then
   echo "❌ Export options plist missing at $EXPORT_OPTIONS_PLIST" >&2
   exit 1
@@ -23,23 +18,27 @@ fi
 
 mkdir -p "$(dirname "$ARCHIVE_PATH")" "$EXPORT_PATH"
 
-cat <<INFO
-==============================================
-🏗️  TradeLine 24/7 iOS Build
-==============================================
-Workspace: ios/${XCODE_WORKSPACE}
-Scheme:    ${XCODE_SCHEME}
-Config:    ${CONFIGURATION}
-Archive:   ${ARCHIVE_PATH}
-Export:    ${EXPORT_PATH}
-==============================================
-INFO
+echo "=============================================="
+echo "🏗️  TradeLine 24/7 iOS Build"
+echo "=============================================="
+echo "Workspace: ios/${XCODE_WORKSPACE}"
+echo "Scheme:    ${XCODE_SCHEME}"
+echo "Config:    ${CONFIGURATION}"
+echo "Archive:   ${ARCHIVE_PATH}"
+echo "Export:    ${EXPORT_PATH}"
+echo "=============================================="
 
 echo "[build-ios] Building web assets..."
 npm run build
 
 echo "[build-ios] Syncing Capacitor iOS project..."
 npx cap sync ios
+
+# Check for workspace AFTER Capacitor sync creates it
+if [[ ! -f "ios/${XCODE_WORKSPACE}" ]]; then
+  echo "❌ Xcode workspace ios/${XCODE_WORKSPACE} not found" >&2
+  exit 1
+fi
 
 echo "[build-ios] Installing CocoaPods dependencies..."
 pushd ios/App >/dev/null


### PR DESCRIPTION
CRITICAL FIX: Move Capacitor sync before workspace check
- Capacitor sync creates the workspace file, so check must happen after
- Fixes 'Xcode workspace not found' error blocking TestFlight deployment
- Maintains all existing functionality and CI compatibility
- Clean, production-ready script with proper error handling

This resolves the Codemagic build regression and enables App Store Connect uploads.

## Changes

<!-- Brief description of what changed -->

## React Hooks Checklist (H310-8)

- [ ] All hooks are at top-level (no conditional/looped hooks)
- [ ] No component function calls (e.g., `Component()` → use `<Component/>`)
- [ ] No early returns before hooks complete
- [ ] ESLint passes with zero hook warnings

## Evidence

## Supabase Auth URL Configuration

- [ ] Site URL set to production domain in Supabase Auth settings
- [ ] Redirect URLs cover magic-link and password-reset flows (HTTPS, no stray trailing slashes)

- [ ] Evidence attached (links to `/ops/twilio-evidence` or test results)
- [ ] Synthetic-smoke passing ([latest run](https://github.com/apex-business-systems/tradeline247/actions/workflows/synthetic-smoke.yml))
- [ ] Twilio Debugger webhook targets `ops-twilio-debugger-intake` (HTTPS)
- [ ] No new secrets in repo (all secrets go to GitHub environments)
- [ ] Store disclosure unchanged or updated (if applicable)

## Testing

<!-- How was this tested? -->

## Deployment Notes

<!-- Any special deployment considerations? -->

---

**For Ops Incidents:** Include CallSid/MessageSid, endpoint, timestamp, and [Twilio Debugger](https://console.twilio.com/us1/monitor/debugger) link.

