### PR TITLE
Harden Codemagic iOS build pipeline

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -34,15 +34,17 @@ workflows:
       - name: Build archive & IPA
         script: |
           chmod +x scripts/build-ios.sh
-          scripts/build-ios.sh
+          ./scripts/build-ios.sh
       - name: Upload to TestFlight
         script: |
           bundle config set path 'vendor/bundle'
           bundle install
           cd ios
-          BUNDLE_GEMFILE=../Gemfile BUNDLE_PATH=../vendor/bundle bundle exec fastlane ios upload
+          BUNDLE_GEMFILE=../Gemfile BUNDLE_PATH=../vendor/bundle bundle exec fastlane ios upload || fastlane ios upload
       - name: Verify artifacts
-        script: bash scripts/verify-codemagic.sh
+        script: |
+          chmod +x scripts/verify-codemagic.sh
+          ./scripts/verify-codemagic.sh
     artifacts:
       - ios/build/export/*.ipa
       - ios/build/TradeLine247.xcarchive

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -3,16 +3,17 @@
 platform :ios do
   desc "Upload IPA to TestFlight using App Store Connect API key"
   lane :upload do
-    key_id = ENV.fetch("APP_STORE_CONNECT_KEY_IDENTIFIER")
-    issuer_id = ENV.fetch("APP_STORE_CONNECT_ISSUER_ID")
-    key_content_raw = ENV.fetch("APP_STORE_CONNECT_PRIVATE_KEY")
-
-    key_content = if key_content_raw.include?("\\n") && !key_content_raw.include?("\n")
-      key_content_raw.gsub("\\n", "\n")
-    else
-      key_content_raw
+    def fetch_env!(key)
+      value = ENV[key]&.strip
+      UI.user_error!("❌ Missing required env var #{key}") if value.nil? || value.empty?
+      value
     end
 
+    key_id = fetch_env!("APP_STORE_CONNECT_KEY_IDENTIFIER")
+    issuer_id = fetch_env!("APP_STORE_CONNECT_ISSUER_ID")
+    key_content_raw = fetch_env!("APP_STORE_CONNECT_PRIVATE_KEY")
+
+    key_content = key_content_raw.include?("\\n") ? key_content_raw.gsub("\\n", "\n") : key_content_raw
     is_base64 = key_content.strip.start_with?("LS0t") && !key_content.include?("BEGIN PRIVATE KEY")
 
     api_key = app_store_connect_api_key(
@@ -26,23 +27,15 @@ platform :ios do
 
     ios_root = File.expand_path("..", __dir__)
     ipa_env = ENV["IPA_PATH"]&.strip
-    ipa_candidates = [ipa_env, File.join(ios_root, "build", "export", "ipa_path.txt")].compact
+    ipa_from_env = if ipa_env && !ipa_env.empty?
+      File.expand_path(ipa_env, ios_root)
+    end
 
     ipa_path = nil
 
-    ipa_candidates.each do |candidate|
-      next if candidate.nil? || candidate.empty?
-
-      if File.file?(candidate) && File.extname(candidate) == ".ipa"
-        ipa_path = candidate
-        break
-      elsif File.file?(candidate) && File.basename(candidate) == "ipa_path.txt"
-        ipa_path = File.read(candidate).strip
-        break if ipa_path && !ipa_path.empty?
-      end
-    end
-
-    if ipa_path.nil? || ipa_path.empty? || !File.exist?(ipa_path)
+    if ipa_from_env && File.exist?(ipa_from_env)
+      ipa_path = ipa_from_env
+    else
       exported_ipas = Dir.glob(File.join(ios_root, "build", "export", "*.ipa"))
       ipa_path = exported_ipas.max_by { |path| File.mtime(path) } if exported_ipas.any?
     end

--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -11,10 +11,92 @@ EXPORT_OPTIONS_PLIST="${EXPORT_OPTIONS_PLIST:-ios/ExportOptions.plist}"
 ARCHIVE_PATH="${ARCHIVE_PATH:-ios/build/TradeLine247.xcarchive}"
 EXPORT_PATH="${EXPORT_PATH:-ios/build/export}"
 
-if [[ ! -f "ios/${XCODE_WORKSPACE}" ]]; then
-  echo "❌ Xcode workspace ios/${XCODE_WORKSPACE} not found" >&2
-  exit 1
+log() {
+  echo "[build-ios] $*"
+}
+
+echo "[build-ios] Working directory: $(pwd)"
+
+log "Building web assets..."
+npm run build
+
+log "Syncing Capacitor iOS project..."
+npx cap sync ios
+
+if [[ -d "ios/App" && -f "ios/App/Podfile" ]]; then
+  log "Installing CocoaPods dependencies..."
+  pushd ios/App >/dev/null
+  pod install --repo-update
+  popd >/dev/null
+else
+  log "Skipping CocoaPods install (Podfile not found)"
 fi
+
+normalize_workspace_input() {
+  local workspace_input="$1"
+
+  if [[ -z "$workspace_input" ]]; then
+    echo ""
+    return
+  fi
+
+  # Strip leading ios/ if provided and make it relative to ios/
+  workspace_input="${workspace_input#ios/}"
+  workspace_input="${workspace_input#./}"
+
+  if [[ "$workspace_input" == /* ]]; then
+    echo "$workspace_input"
+  else
+    echo "ios/${workspace_input}"
+  fi
+}
+
+find_workspace() {
+  local normalized_input
+  normalized_input=$(normalize_workspace_input "$1")
+  declare -a candidates searched
+
+  if [[ -n "$normalized_input" ]]; then
+    candidates+=("$normalized_input")
+    searched+=("$normalized_input")
+  fi
+
+  if [[ -d "ios/App" ]]; then
+    while IFS= read -r path; do
+      candidates+=("$path")
+    done < <(find ios/App -maxdepth 2 -name "*.xcworkspace" -type f 2>/dev/null | sort)
+  fi
+
+  while IFS= read -r path; do
+    # Avoid duplicates
+    [[ " ${candidates[*]} " == *" $path "* ]] && continue
+    candidates+=("$path")
+  done < <(find ios -maxdepth 2 -name "*.xcworkspace" -type f 2>/dev/null | sort)
+
+  local workspace=""
+  for candidate in "${candidates[@]}"; do
+    searched+=("$candidate")
+    if [[ -f "$candidate" ]]; then
+      workspace="$candidate"
+      break
+    fi
+  done
+
+  if [[ -z "$workspace" ]]; then
+    echo ""
+    echo "CRITICAL: Could not find Xcode workspace file!" >&2
+    echo "Searched:" >&2
+    printf '  - %s\n' "${searched[@]}" >&2
+    cat >&2 <<'HINT'
+Hint: Ensure Capacitor iOS project exists (npx cap add ios) and that CocoaPods generated an .xcworkspace (check ios/App/Podfile).
+HINT
+    exit 1
+  fi
+
+  echo "$workspace"
+}
+
+WORKSPACE_PATH=$(find_workspace "$XCODE_WORKSPACE")
 
 if [[ ! -f "$EXPORT_OPTIONS_PLIST" ]]; then
   echo "❌ Export options plist missing at $EXPORT_OPTIONS_PLIST" >&2
@@ -27,7 +109,8 @@ cat <<INFO
 ==============================================
 🏗️  TradeLine 24/7 iOS Build
 ==============================================
-Workspace: ios/${XCODE_WORKSPACE}
+CWD:       $(pwd)
+Workspace: ${WORKSPACE_PATH}
 Scheme:    ${XCODE_SCHEME}
 Config:    ${CONFIGURATION}
 Archive:   ${ARCHIVE_PATH}
@@ -35,20 +118,9 @@ Export:    ${EXPORT_PATH}
 ==============================================
 INFO
 
-echo "[build-ios] Building web assets..."
-npm run build
-
-echo "[build-ios] Syncing Capacitor iOS project..."
-npx cap sync ios
-
-echo "[build-ios] Installing CocoaPods dependencies..."
-pushd ios/App >/dev/null
-pod install --repo-update
-popd >/dev/null
-
-echo "[build-ios] Archiving app..."
+log "Archiving app..."
 xcodebuild archive \
-  -workspace "ios/${XCODE_WORKSPACE}" \
+  -workspace "${WORKSPACE_PATH}" \
   -scheme "${XCODE_SCHEME}" \
   -configuration "${CONFIGURATION}" \
   -destination "generic/platform=iOS" \
@@ -56,14 +128,14 @@ xcodebuild archive \
   -allowProvisioningUpdates \
   clean archive
 
-echo "[build-ios] Exporting IPA..."
+log "Exporting IPA..."
 xcodebuild -exportArchive \
   -archivePath "${ARCHIVE_PATH}" \
   -exportOptionsPlist "${EXPORT_OPTIONS_PLIST}" \
   -exportPath "${EXPORT_PATH}" \
   -allowProvisioningUpdates
 
-IPA_PATH=$(find "${EXPORT_PATH}" -maxdepth 1 -name "*.ipa" | head -1)
+IPA_PATH=$(find "${EXPORT_PATH}" -maxdepth 1 -name "*.ipa" -print0 | xargs -0 ls -t 2>/dev/null | head -1 || true)
 
 if [[ -z "${IPA_PATH}" || ! -f "${IPA_PATH}" ]]; then
   echo "❌ IPA not found in ${EXPORT_PATH}" >&2
@@ -73,8 +145,10 @@ fi
 export IPA_PATH
 printf "%s" "${IPA_PATH}" > "${EXPORT_PATH}/ipa_path.txt"
 
-echo "=============================================="
-echo "✅ BUILD SUCCESSFUL"
-echo "Archive: ${ARCHIVE_PATH}"
-echo "IPA:     ${IPA_PATH}"
-echo "=============================================="
+cat <<SUCCESS
+==============================================
+✅ BUILD SUCCESSFUL
+Archive: ${ARCHIVE_PATH}
+IPA:     ${IPA_PATH}
+==============================================
+SUCCESS

--- a/scripts/verify-codemagic.sh
+++ b/scripts/verify-codemagic.sh
@@ -4,28 +4,26 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ARCHIVE_PATH="${ARCHIVE_PATH:-$ROOT/ios/build/TradeLine247.xcarchive}"
 EXPORT_PATH="${EXPORT_PATH:-$ROOT/ios/build/export}"
-IPA_GLOB="${IPA_GLOB:-$EXPORT_PATH/*.ipa}"
 OUTPUT_FILE="${OUTPUT_FILE:-$ROOT/build-artifacts-sha256.txt}"
-
-shopt -s nullglob
-ipas=( $IPA_GLOB )
 
 if [[ ! -d "$ARCHIVE_PATH" ]]; then
   echo "❌ Archive missing at $ARCHIVE_PATH" >&2
   exit 1
 fi
 
+shopt -s nullglob
+ipas=("${EXPORT_PATH}"/*.ipa)
+
 if [[ ${#ipas[@]} -eq 0 ]]; then
-  echo "❌ No IPA found at $IPA_GLOB" >&2
+  echo "❌ No IPA found in ${EXPORT_PATH}" >&2
   exit 1
 fi
 
 : > "$OUTPUT_FILE"
-
 echo "[verify-codemagic] Computing SHA256 checksums" >&2
+
 archive_dir=$(dirname "$ARCHIVE_PATH")
 archive_name=$(basename "$ARCHIVE_PATH")
-
 archive_checksum=$( (cd "$archive_dir" && tar -cf - "$archive_name") | shasum -a 256 | awk '{print $1}' )
 printf "%s  %s\n" "$archive_checksum" "$ARCHIVE_PATH" | tee -a "$OUTPUT_FILE"
 


### PR DESCRIPTION
## Summary
- run the iOS build script from project root, sync/pod install up front, and auto-detect the generated xcworkspace with clear failure hints
- tighten the Fastlane upload lane to validate App Store Connect env vars, normalize the key content, and pick the correct IPA
- harden artifact verification and align the Codemagic workflow with the updated scripts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6923767d6800832da5dc6b984c18ef11)