### PR TITLE
Align build-ios script with Codemagic CLI flow

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -32,14 +32,79 @@ workflows:
       
       - name: Quality gates
         script: npm run lint && npm run typecheck && npm run test:unit
-      
+
       - name: Playwright smoke
         script: |
           npx playwright install --with-deps chromium
           npm run test:e2e:smoke
-      
+
+      - name: Set up code signing identities
+        script: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          echo "[codesign] Initializing keychain and fetching signing assets"
+          keychain initialize
+
+          echo "[codesign] Fetching provisioning profiles for ${BUNDLE_ID}"
+          app-store-connect fetch-signing-files "$BUNDLE_ID" --type IOS_APP_STORE --create
+
+          echo "[codesign] Importing certificates into the keychain"
+          keychain add-certificates
+
       - name: Build archive & IPA
-        script: bash scripts/build-ios.sh
+        script: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          echo "[build-ios] Workspace: ${XCODE_WORKSPACE:-ios/App/App.xcworkspace}"
+          echo "[build-ios] Scheme:   ${XCODE_SCHEME:-App}"
+          echo "[build-ios] Config:   ${CONFIGURATION:-Release}"
+
+          # Ensure codemagic-cli-tools are available (safe to re-run even if installed earlier)
+          pip3 install codemagic-cli-tools --upgrade
+
+          # Apply the fetched provisioning profiles to the Xcode project/workspace
+          echo "[build-ios] Applying provisioning profiles via xcode-project use-profiles..."
+          xcode-project use-profiles
+
+          # Build archive + IPA using Codemagic's Xcode wrapper
+          echo "[build-ios] Building IPA via xcode-project build-ipa..."
+          xcode-project build-ipa \
+            --workspace "${XCODE_WORKSPACE:-ios/App/App.xcworkspace}" \
+            --scheme "${XCODE_SCHEME:-App}" \
+            --log-path /tmp/xcodebuild_logs
+
+          echo "[build-ios] Locating generated IPA and .xcarchive..."
+          set +u
+          IPA_SOURCE="$(find build -type f -name '*.ipa' | head -1)"
+          ARCHIVE_SOURCE="$(find build -type d -name '*.xcarchive' | head -1)"
+          set -u
+
+          if [ -z "${IPA_SOURCE:-}" ] || [ ! -f "${IPA_SOURCE:-/dev/null}" ]; then
+            echo "❌ No IPA produced by xcode-project build-ipa" >&2
+            exit 70
+          fi
+
+          mkdir -p ios/build/export ios/build
+
+          # Copy IPA to legacy path expected by artifacts / any downstream scripts
+          cp "${IPA_SOURCE}" ios/build/export/TradeLine247.ipa
+          ABS_IPA_PATH="$(pwd)/ios/build/export/TradeLine247.ipa"
+          printf "%s" "${ABS_IPA_PATH}" > ipa_path.txt
+          printf "%s" "${ABS_IPA_PATH}" > ios/build/export/ipa_path.txt
+
+          # Copy archive to legacy path if present
+          if [ -n "${ARCHIVE_SOURCE:-}" ] && [ -d "${ARCHIVE_SOURCE:-}" ]; then
+            rm -rf ios/build/TradeLine247.xcarchive
+            cp -R "${ARCHIVE_SOURCE}" ios/build/TradeLine247.xcarchive
+          fi
+
+          echo "=============================================="
+          echo "✅ iOS archive & IPA successfully built"
+          echo "    IPA:     ios/build/export/TradeLine247.ipa"
+          echo "    Archive: ios/build/TradeLine247.xcarchive"
+          echo "=============================================="
       
       - name: 🚀 Upload to TestFlight
         script: |
@@ -93,6 +158,10 @@ workflows:
     artifacts:
       - ios/build/export/*.ipa
       - ios/build/TradeLine247.xcarchive
+      - build/ios/ipa/*.ipa
+      - /tmp/xcodebuild_logs/*.log
+      - $HOME/Library/Developer/Xcode/DerivedData/**/Build/**/*.app
+      - $HOME/Library/Developer/Xcode/DerivedData/**/Build/**/*.dSYM
       - playwright-report/**/*
       - dist/**/*
       - build-artifacts-sha256.txt

--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -1,78 +1,51 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Use environment variables from Codemagic
-WORKSPACE="${XCODE_WORKSPACE}"
-SCHEME="${XCODE_SCHEME}"
-CONFIGURATION="Release"
-ARCHIVE_PATH="/Users/builder/clone/ios/build/TradeLine247.xcarchive"
-EXPORT_PATH="/Users/builder/clone/ios/build/export"
+WORKSPACE="${XCODE_WORKSPACE:-ios/App/App.xcworkspace}"
+SCHEME="${XCODE_SCHEME:-App}"
+CONFIGURATION="${CONFIGURATION:-Release}"
 
-echo "[build-ios] Using workspace: ${WORKSPACE}"
-echo "[build-ios] Using scheme: ${SCHEME}"
-echo "[build-ios] Configuration: ${CONFIGURATION}"
-echo "[build-ios] Archive path: ${ARCHIVE_PATH}"
-echo "[build-ios] Export path: ${EXPORT_PATH}"
+echo "[build-ios] Workspace: ${WORKSPACE}"
+echo "[build-ios] Scheme:   ${SCHEME}"
+echo "[build-ios] Config:   ${CONFIGURATION}"
 
-# Archive
-echo "[build-ios] Archiving iOS app..."
-xcodebuild archive \
-  -workspace "${WORKSPACE}" \
-  -scheme "${SCHEME}" \
-  -configuration "${CONFIGURATION}" \
-  -archivePath "${ARCHIVE_PATH}" \
-  -allowProvisioningUpdates \
-  CODE_SIGN_STYLE=Manual \
-  CODE_SIGN_IDENTITY="Apple Distribution: 2755419 Alberta Ltd (NWGUYF42KW)" \
-  DEVELOPMENT_TEAM="${TEAM_ID}" \
-  PROVISIONING_PROFILE_SPECIFIER="TL247_mobpro_tradeline_01" \
-  | xcpretty
+echo "[build-ios] Ensuring codemagic-cli-tools are available..."
+pip3 install codemagic-cli-tools --upgrade
 
-# Export IPA
-echo "[build-ios] Exporting IPA..."
+echo "[build-ios] Applying provisioning profiles via xcode-project use-profiles..."
+xcode-project use-profiles
 
-# Create export options plist
-cat > /tmp/exportOptions.plist <<EOF
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>method</key>
-    <string>app-store</string>
-    <key>teamID</key>
-    <string>${TEAM_ID}</string>
-    <key>uploadBitcode</key>
-    <false/>
-    <key>uploadSymbols</key>
-    <true/>
-    <key>compileBitcode</key>
-    <false/>
-    <key>signingStyle</key>
-    <string>manual</string>
-    <key>signingCertificate</key>
-    <string>Apple Distribution</string>
-    <key>provisioningProfiles</key>
-    <dict>
-        <key>${BUNDLE_ID}</key>
-        <string>TL247_mobpro_tradeline_01</string>
-    </dict>
-</dict>
-</plist>
-EOF
+echo "[build-ios] Building IPA via xcode-project build-ipa..."
+xcode-project build-ipa \
+  --workspace "${WORKSPACE}" \
+  --scheme "${SCHEME}" \
+  --log-path /tmp/xcodebuild_logs
 
-xcodebuild -exportArchive \
-  -archivePath "${ARCHIVE_PATH}" \
-  -exportPath "${EXPORT_PATH}" \
-  -exportOptionsPlist /tmp/exportOptions.plist \
-  -allowProvisioningUpdates \
-  | xcpretty
+echo "[build-ios] Locating generated IPA and .xcarchive..."
+set +u
+IPA_SOURCE="$(find build -type f -name '*.ipa' | head -1)"
+ARCHIVE_SOURCE="$(find build -type d -name '*.xcarchive' | head -1)"
+set -u
 
-# Find and save IPA path
-IPA_PATH=$(find "${EXPORT_PATH}" -name "*.ipa" | head -1)
-if [ -z "$IPA_PATH" ]; then
-  echo "[build-ios] ERROR: No IPA found in ${EXPORT_PATH}"
-  exit 1
+if [ -z "${IPA_SOURCE:-}" ] || [ ! -f "${IPA_SOURCE:-/dev/null}" ]; then
+  echo "❌ No IPA produced by xcode-project build-ipa" >&2
+  exit 70
 fi
 
-echo "[build-ios] ✅ IPA created: ${IPA_PATH}"
-echo "${IPA_PATH}" > /Users/builder/clone/ipa_path.txt
+mkdir -p ios/build/export ios/build
+
+cp "${IPA_SOURCE}" ios/build/export/TradeLine247.ipa
+ABS_IPA_PATH="$(pwd)/ios/build/export/TradeLine247.ipa"
+printf "%s" "${ABS_IPA_PATH}" > ipa_path.txt
+printf "%s" "${ABS_IPA_PATH}" > ios/build/export/ipa_path.txt
+
+if [ -n "${ARCHIVE_SOURCE:-}" ] && [ -d "${ARCHIVE_SOURCE:-}" ]; then
+  rm -rf ios/build/TradeLine247.xcarchive
+  cp -R "${ARCHIVE_SOURCE}" ios/build/TradeLine247.xcarchive
+fi
+
+echo "=============================================="
+echo "✅ iOS archive & IPA successfully built"
+echo "    IPA:     ios/build/export/TradeLine247.ipa"
+echo "    Archive: ios/build/TradeLine247.xcarchive"
+echo "=============================================="


### PR DESCRIPTION
## Summary
- update scripts/build-ios.sh to mirror the Codemagic CLI-based provisioning and build process
- ensure IPA and archive artifacts are copied to legacy paths and absolute IPA path files are written for downstream steps

## Testing
- Not run (CI configuration change only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6924616c701c832d8f4d131296187c0e)