### PR TITLE
Fix/ios workspace path correction

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -26,7 +26,7 @@ workflows:
 
         XCODE_SCHEME: App
 
-        XCODE_WORKSPACE: App/App.xcworkspace
+        XCODE_WORKSPACE: ios/App/App.xcworkspace
 
         BUNDLE_ID: com.apex.tradeline
 

--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -2,14 +2,14 @@
 set -euo pipefail
 
 # Use environment variables from Codemagic
-WORKSPACE="${XCODE_WORKSPACE}"
-SCHEME="${XCODE_SCHEME}"
+PROJECT_PATH="ios/App/App.xcodeproj"
+TARGET="App"
 CONFIGURATION="Release"
 ARCHIVE_PATH="/Users/builder/clone/ios/build/TradeLine247.xcarchive"
 EXPORT_PATH="/Users/builder/clone/ios/build/export"
 
-echo "[build-ios] Using workspace: ${WORKSPACE}"
-echo "[build-ios] Using scheme: ${SCHEME}"
+echo "[build-ios] Using project: ${PROJECT_PATH}"
+echo "[build-ios] Using target: ${TARGET}"
 echo "[build-ios] Configuration: ${CONFIGURATION}"
 echo "[build-ios] Archive path: ${ARCHIVE_PATH}"
 echo "[build-ios] Export path: ${EXPORT_PATH}"
@@ -17,8 +17,8 @@ echo "[build-ios] Export path: ${EXPORT_PATH}"
 # Archive
 echo "[build-ios] Archiving iOS app..."
 xcodebuild archive \
-  -workspace "${WORKSPACE}" \
-  -scheme "${SCHEME}" \
+  -project "${PROJECT_PATH}" \
+  -target "${TARGET}" \
   -configuration "${CONFIGURATION}" \
   -archivePath "${ARCHIVE_PATH}" \
   -allowProvisioningUpdates \


### PR DESCRIPTION
## Changes

<!-- Brief description of what changed -->

## React Hooks Checklist (H310-8)

- [ ] All hooks are at top-level (no conditional/looped hooks)
- [ ] No component function calls (e.g., `Component()` → use `<Component/>`)
- [ ] No early returns before hooks complete
- [ ] ESLint passes with zero hook warnings

## Evidence

## Supabase Auth URL Configuration

- [ ] Site URL set to production domain in Supabase Auth settings
- [ ] Redirect URLs cover magic-link and password-reset flows (HTTPS, no stray trailing slashes)

- [ ] Evidence attached (links to `/ops/twilio-evidence` or test results)
- [ ] Synthetic-smoke passing ([latest run](https://github.com/apex-business-systems/tradeline247/actions/workflows/synthetic-smoke.yml))
- [ ] Twilio Debugger webhook targets `ops-twilio-debugger-intake` (HTTPS)
- [ ] No new secrets in repo (all secrets go to GitHub environments)
- [ ] Store disclosure unchanged or updated (if applicable)

## Testing

<!-- How was this tested? -->

## Deployment Notes

<!-- Any special deployment considerations? -->

---

**For Ops Incidents:** Include CallSid/MessageSid, endpoint, timestamp, and [Twilio Debugger](https://console.twilio.com/us1/monitor/debugger) link.

