### PR TITLE
Fix TradeLine iOS build pipeline exit code 65

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -73,6 +73,7 @@ workflows:
           xcode-project build-ipa \
             --workspace "${XCODE_WORKSPACE:-ios/App/App.xcworkspace}" \
             --scheme "${XCODE_SCHEME:-App}" \
+            --config "${CONFIGURATION:-Release}" \
             --log-path /tmp/xcodebuild_logs
 
           echo "[build-ios] Locating generated IPA and .xcarchive..."

--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -19,6 +19,7 @@ echo "[build-ios] Building IPA via xcode-project build-ipa..."
 xcode-project build-ipa \
   --workspace "${WORKSPACE}" \
   --scheme "${SCHEME}" \
+  --config "${CONFIGURATION}" \
   --log-path /tmp/xcodebuild_logs
 
 echo "[build-ios] Locating generated IPA and .xcarchive..."


### PR DESCRIPTION
…exit 65 fix)

Root Cause:
- Commit 614807b refactored build-ios.sh from manual xcodebuild to xcode-project build-ipa
- The --config parameter was omitted during refactoring
- Without configuration specified, xcodebuild cannot determine target platforms
- Error: "Supported platforms for buildables is empty" (exit code 65)

Solution:
- Add --config "${CONFIGURATION:-Release}" parameter to xcode-project build-ipa
- Applied to both codemagic.yaml and scripts/build-ios.sh for consistency
- Ensures Release configuration is used for App Store builds

Changes:
- codemagic.yaml line 76: Added --config parameter to build-ipa command
- scripts/build-ios.sh line 22: Added --config parameter to build-ipa command
- Both use ${CONFIGURATION:-Release} with Release as safe default

Reference:
- Codemagic CLI build-ipa requires explicit --config for proper platform detection
- Previous working approach (3b9d5f9) used -configuration with manual xcodebuild
- This restores equivalent functionality with Codemagic CLI tools

Verification:
- YAML syntax validated
- Both inline script and external script updated
- No changes to signing, artifacts, or other workflows
- Minimal surgical fix to resolve exit 65

Testing:
- Trigger Codemagic build to verify archive succeeds
- Expect "** ARCHIVE SUCCEEDED **" and "** EXPORT SUCCEEDED **"
- IPA should be created at ios/build/export/TradeLine247.ipa

Rollback: git revert HEAD
Backup: backup/pre-config-fix-20251124 (local branch)

## Changes

<!-- Brief description of what changed -->

## React Hooks Checklist (H310-8)

- [ ] All hooks are at top-level (no conditional/looped hooks)
- [ ] No component function calls (e.g., `Component()` → use `<Component/>`)
- [ ] No early returns before hooks complete
- [ ] ESLint passes with zero hook warnings

## Evidence

## Supabase Auth URL Configuration

- [ ] Site URL set to production domain in Supabase Auth settings
- [ ] Redirect URLs cover magic-link and password-reset flows (HTTPS, no stray trailing slashes)

- [ ] Evidence attached (links to `/ops/twilio-evidence` or test results)
- [ ] Synthetic-smoke passing ([latest run](https://github.com/apex-business-systems/tradeline247/actions/workflows/synthetic-smoke.yml))
- [ ] Twilio Debugger webhook targets `ops-twilio-debugger-intake` (HTTPS)
- [ ] No new secrets in repo (all secrets go to GitHub environments)
- [ ] Store disclosure unchanged or updated (if applicable)

## Testing

<!-- How was this tested? -->

## Deployment Notes

<!-- Any special deployment considerations? -->

---

**For Ops Incidents:** Include CallSid/MessageSid, endpoint, timestamp, and [Twilio Debugger](https://console.twilio.com/us1/monitor/debugger) link.

