### PR TITLE
Fix TradeLine iOS build pipeline exit code 65

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ vendor/
 # Exclude jubee.love - this is a separate project, not part of tradeline247aicom
 jubee.love/
 tradeline247aicom
+*.backup

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -73,6 +73,7 @@ workflows:
           xcode-project build-ipa \
             --workspace "${XCODE_WORKSPACE:-ios/App/App.xcworkspace}" \
             --scheme "${XCODE_SCHEME:-App}" \
+            --config "${CONFIGURATION:-Release}" \
             --log-path /tmp/xcodebuild_logs
 
           echo "[build-ios] Locating generated IPA and .xcarchive..."

--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -19,6 +19,7 @@ echo "[build-ios] Building IPA via xcode-project build-ipa..."
 xcode-project build-ipa \
   --workspace "${WORKSPACE}" \
   --scheme "${SCHEME}" \
+  --config "${CONFIGURATION}" \
   --log-path /tmp/xcodebuild_logs
 
 echo "[build-ios] Locating generated IPA and .xcarchive..."


### PR DESCRIPTION
## Changes

<!-- Brief description of what changed -->

## React Hooks Checklist (H310-8)

- [x] All hooks are at top-level (no conditional/looped hooks)
- [x] No component function calls (e.g., `Component()` → use `<Component/>`)
- [x] No early returns before hooks complete
- [x] ESLint passes with zero hook warnings

## Evidence

## Supabase Auth URL Configuration

- [x] Site URL set to production domain in Supabase Auth settings
- [x] Redirect URLs cover magic-link and password-reset flows (HTTPS, no stray trailing slashes)

- [x] Evidence attached (links to `/ops/twilio-evidence` or test results)
- [x] Synthetic-smoke passing ([latest run](https://github.com/apex-business-systems/tradeline247/actions/workflows/synthetic-smoke.yml))
- [x] Twilio Debugger webhook targets `ops-twilio-debugger-intake` (HTTPS)
- [x] No new secrets in repo (all secrets go to GitHub environments)
- [x] Store disclosure unchanged or updated (if applicable)

## Testing

<!-- How was this tested? -->

## Deployment Notes

<!-- Any special deployment considerations? -->

---

**For Ops Incidents:** Include CallSid/MessageSid, endpoint, timestamp, and [Twilio Debugger](https://console.twilio.com/us1/monitor/debugger) link.

