### PR TITLE
fix(ios): correct XCODE_WORKSPACE path to ios/App/App.xcworkspace

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -26,7 +26,7 @@ workflows:
 
         XCODE_SCHEME: App
 
-        XCODE_WORKSPACE: App/App.xcworkspace
+        XCODE_WORKSPACE: ios/App/App.xcworkspace
 
         BUNDLE_ID: com.apex.tradeline
 


### PR DESCRIPTION
Root cause: Environment variable XCODE_WORKSPACE missing ios/ prefix
Error: xcodebuild: error: 'App/App.xcworkspace' does not exist
Fix: Added ios/ prefix to workspace path in codemagic.yaml:29
Reference: GOODBUILD.txt shows XCODE_WORKSPACE=ios/App/App.xcworkspace
Evidence: GOODBUILD.txt line 12: XCODE_WORKSPACE=ios/App/App.xcworkspace
Impact: Minimal - single path correction, no logic changes
Verification: Build logs will show correct workspace path
Rollback: git revert <this_commit_hash> (single line change)

## Changes

<!-- Brief description of what changed -->

## React Hooks Checklist (H310-8)

- [ ] All hooks are at top-level (no conditional/looped hooks)
- [ ] No component function calls (e.g., `Component()` → use `<Component/>`)
- [ ] No early returns before hooks complete
- [ ] ESLint passes with zero hook warnings

## Evidence

## Supabase Auth URL Configuration

- [ ] Site URL set to production domain in Supabase Auth settings
- [ ] Redirect URLs cover magic-link and password-reset flows (HTTPS, no stray trailing slashes)

- [ ] Evidence attached (links to `/ops/twilio-evidence` or test results)
- [ ] Synthetic-smoke passing ([latest run](https://github.com/apex-business-systems/tradeline247/actions/workflows/synthetic-smoke.yml))
- [ ] Twilio Debugger webhook targets `ops-twilio-debugger-intake` (HTTPS)
- [ ] No new secrets in repo (all secrets go to GitHub environments)
- [ ] Store disclosure unchanged or updated (if applicable)

## Testing

<!-- How was this tested? -->

## Deployment Notes

<!-- Any special deployment considerations? -->

---

**For Ops Incidents:** Include CallSid/MessageSid, endpoint, timestamp, and [Twilio Debugger](https://console.twilio.com/us1/monitor/debugger) link.

