### PR TITLE
Ensure manual iOS signing without App Store Connect step

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -62,49 +62,73 @@ workflows:
           #!/usr/bin/env bash
           set -euo pipefail
 
-          echo "[build-ios] Workspace: ${XCODE_WORKSPACE:-ios/App/App.xcworkspace}"
-          echo "[build-ios] Scheme:   ${XCODE_SCHEME:-App}"
-          echo "[build-ios] Config:   ${CONFIGURATION:-Release}"
+          WORKSPACE="${XCODE_WORKSPACE:-ios/App/App.xcworkspace}"
+          SCHEME="${XCODE_SCHEME:-App}"
+          CONFIGURATION="${CONFIGURATION:-Release}"
+          PROFILE_SPECIFIER="TL247_mobpro_tradeline_01"
+          EXPORT_OPTIONS="/tmp/exportOptions.plist"
 
-          # Ensure codemagic-cli-tools are available (safe to re-run even if installed earlier)
-          pip3 install codemagic-cli-tools --upgrade
+          echo "[build-ios] Workspace: ${WORKSPACE}"
+          echo "[build-ios] Scheme:   ${SCHEME}"
+          echo "[build-ios] Config:   ${CONFIGURATION}"
 
-          # Apply the fetched provisioning profiles to the Xcode project/workspace
-          echo "[build-ios] Applying provisioning profiles via xcode-project use-profiles..."
-          xcode-project use-profiles
+          mkdir -p ios/build/export
 
-          # Build archive + IPA using Codemagic's Xcode wrapper
-          echo "[build-ios] Building IPA via xcode-project build-ipa..."
-          xcode-project build-ipa \
-            --workspace "${XCODE_WORKSPACE:-ios/App/App.xcworkspace}" \
-            --scheme "${XCODE_SCHEME:-App}" \
-            --config "${CONFIGURATION:-Release}" \
-            --log-path /tmp/xcodebuild_logs
+          cat >"${EXPORT_OPTIONS}" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>method</key>
+  <string>app-store</string>
+  <key>signingStyle</key>
+  <string>manual</string>
+  <key>teamID</key>
+  <string>${TEAM_ID}</string>
+  <key>provisioningProfiles</key>
+  <dict>
+    <key>${BUNDLE_ID}</key>
+    <string>${PROFILE_SPECIFIER}</string>
+  </dict>
+  <key>uploadSymbols</key>
+  <true/>
+  <key>stripSwiftSymbols</key>
+  <true/>
+  <key>compileBitcode</key>
+  <false/>
+</dict>
+</plist>
+EOF
 
-          echo "[build-ios] Locating generated IPA and .xcarchive..."
-          set +u
-          IPA_SOURCE="$(find build -type f -name '*.ipa' | head -1)"
-          ARCHIVE_SOURCE="$(find build -type d -name '*.xcarchive' | head -1)"
-          set -u
+          echo "[build-ios] Archiving with manual signing..."
+          xcodebuild \
+            -workspace "${WORKSPACE}" \
+            -scheme "${SCHEME}" \
+            -configuration "${CONFIGURATION}" \
+            -archivePath ios/build/TradeLine247.xcarchive \
+            CODE_SIGN_STYLE=Manual \
+            DEVELOPMENT_TEAM="${TEAM_ID}" \
+            PROVISIONING_PROFILE_SPECIFIER="${PROFILE_SPECIFIER}" \
+            archive
+
+          echo "[build-ios] Exporting IPA via xcodebuild -exportArchive..."
+          xcodebuild -exportArchive \
+            -archivePath ios/build/TradeLine247.xcarchive \
+            -exportOptionsPlist "${EXPORT_OPTIONS}" \
+            -exportPath ios/build/export
+
+          echo "[build-ios] Locating generated IPA..."
+          IPA_SOURCE="$(find ios/build/export -type f -name '*.ipa' | head -1)"
 
           if [ -z "${IPA_SOURCE:-}" ] || [ ! -f "${IPA_SOURCE:-/dev/null}" ]; then
-            echo "❌ No IPA produced by xcode-project build-ipa" >&2
+            echo "❌ No IPA produced by xcodebuild export" >&2
             exit 70
           fi
 
-          mkdir -p ios/build/export ios/build
-
-          # Copy IPA to legacy path expected by artifacts / any downstream scripts
           cp "${IPA_SOURCE}" ios/build/export/TradeLine247.ipa
           ABS_IPA_PATH="$(pwd)/ios/build/export/TradeLine247.ipa"
           printf "%s" "${ABS_IPA_PATH}" > ipa_path.txt
           printf "%s" "${ABS_IPA_PATH}" > ios/build/export/ipa_path.txt
-
-          # Copy archive to legacy path if present
-          if [ -n "${ARCHIVE_SOURCE:-}" ] && [ -d "${ARCHIVE_SOURCE:-}" ]; then
-            rm -rf ios/build/TradeLine247.xcarchive
-            cp -R "${ARCHIVE_SOURCE}" ios/build/TradeLine247.xcarchive
-          fi
 
           echo "=============================================="
           echo "✅ iOS archive & IPA successfully built"

--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -4,46 +4,70 @@ set -euo pipefail
 WORKSPACE="${XCODE_WORKSPACE:-ios/App/App.xcworkspace}"
 SCHEME="${XCODE_SCHEME:-App}"
 CONFIGURATION="${CONFIGURATION:-Release}"
+PROFILE_SPECIFIER="TL247_mobpro_tradeline_01"
+EXPORT_OPTIONS="/tmp/exportOptions.plist"
 
 echo "[build-ios] Workspace: ${WORKSPACE}"
 echo "[build-ios] Scheme:   ${SCHEME}"
 echo "[build-ios] Config:   ${CONFIGURATION}"
 
-echo "[build-ios] Ensuring codemagic-cli-tools are available..."
-pip3 install codemagic-cli-tools --upgrade
+mkdir -p ios/build/export
 
-echo "[build-ios] Applying provisioning profiles via xcode-project use-profiles..."
-xcode-project use-profiles
+cat >"${EXPORT_OPTIONS}" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>method</key>
+  <string>app-store</string>
+  <key>signingStyle</key>
+  <string>manual</string>
+  <key>teamID</key>
+  <string>${TEAM_ID}</string>
+  <key>provisioningProfiles</key>
+  <dict>
+    <key>${BUNDLE_ID}</key>
+    <string>${PROFILE_SPECIFIER}</string>
+  </dict>
+  <key>uploadSymbols</key>
+  <true/>
+  <key>stripSwiftSymbols</key>
+  <true/>
+  <key>compileBitcode</key>
+  <false/>
+</dict>
+</plist>
+EOF
 
-echo "[build-ios] Building IPA via xcode-project build-ipa..."
-xcode-project build-ipa \
-  --workspace "${WORKSPACE}" \
-  --scheme "${SCHEME}" \
-  --config "${CONFIGURATION}" \
-  --log-path /tmp/xcodebuild_logs
+echo "[build-ios] Archiving with manual signing..."
+xcodebuild \
+  -workspace "${WORKSPACE}" \
+  -scheme "${SCHEME}" \
+  -configuration "${CONFIGURATION}" \
+  -archivePath ios/build/TradeLine247.xcarchive \
+  CODE_SIGN_STYLE=Manual \
+  DEVELOPMENT_TEAM="${TEAM_ID}" \
+  PROVISIONING_PROFILE_SPECIFIER="${PROFILE_SPECIFIER}" \
+  archive
 
-echo "[build-ios] Locating generated IPA and .xcarchive..."
-set +u
-IPA_SOURCE="$(find build -type f -name '*.ipa' | head -1)"
-ARCHIVE_SOURCE="$(find build -type d -name '*.xcarchive' | head -1)"
-set -u
+echo "[build-ios] Exporting IPA via xcodebuild -exportArchive..."
+xcodebuild -exportArchive \
+  -archivePath ios/build/TradeLine247.xcarchive \
+  -exportOptionsPlist "${EXPORT_OPTIONS}" \
+  -exportPath ios/build/export
+
+echo "[build-ios] Locating generated IPA..."
+IPA_SOURCE="$(find ios/build/export -type f -name '*.ipa' | head -1)"
 
 if [ -z "${IPA_SOURCE:-}" ] || [ ! -f "${IPA_SOURCE:-/dev/null}" ]; then
-  echo "❌ No IPA produced by xcode-project build-ipa" >&2
+  echo "❌ No IPA produced by xcodebuild export" >&2
   exit 70
 fi
-
-mkdir -p ios/build/export ios/build
 
 cp "${IPA_SOURCE}" ios/build/export/TradeLine247.ipa
 ABS_IPA_PATH="$(pwd)/ios/build/export/TradeLine247.ipa"
 printf "%s" "${ABS_IPA_PATH}" > ipa_path.txt
 printf "%s" "${ABS_IPA_PATH}" > ios/build/export/ipa_path.txt
-
-if [ -n "${ARCHIVE_SOURCE:-}" ] && [ -d "${ARCHIVE_SOURCE:-}" ]; then
-  rm -rf ios/build/TradeLine247.xcarchive
-  cp -R "${ARCHIVE_SOURCE}" ios/build/TradeLine247.xcarchive
-fi
 
 echo "=============================================="
 echo "✅ iOS archive & IPA successfully built"


### PR DESCRIPTION
## Summary
- keep the single manual code signing step and remove reliance on Codemagic automatic signing
- switch the iOS archive/export phase to explicit xcodebuild commands with manual provisioning profile mapping
- align the reusable build script with the manual signing archive/export flow

## Testing
- not run (CI configuration changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69250c968dc4832d91be464bf8fc52cc)