### PR TITLE
Enforce manual signing path in release iOS workflow

### DIFF
--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -96,26 +96,17 @@ jobs:
           SCHEMES=$(xcodebuild -list -json -workspace "$WORKSPACE")
           echo "$SCHEMES" | grep -q "\"$SCHEME\"" || { echo "::error::Scheme '$SCHEME' not found (ensure it is SHARED and committed)"; exit 65; }
 
-      - name: Determine signing mode
-        id: signing
+      - name: Validate required signing secrets
         run: |
-          if [ -n "${{ secrets.IOS_CERT_P12 }}" ] && [ -n "${{ secrets.IOS_PROFILE }}" ] && [ -n "${{ secrets.IOS_CERT_PASSWORD }}" ]; then
-            echo "mode=manual" >> "$GITHUB_OUTPUT"
-          elif [ -n "${{ secrets.APPLE_API_PRIVATE_KEY }}" ] && [ -n "${{ secrets.APPLE_API_KEY_ID }}" ] && [ -n "${{ secrets.APPLE_API_KEY_ISSUER }}" ]; then
-            echo "mode=api" >> "$GITHUB_OUTPUT"
-          else
-            echo "mode=none" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Abort if signing secrets missing
-        if: steps.signing.outputs.mode == 'none'
-        run: |
-          echo "::error::No signing credentials provided. Supply manual (.p12 + profile) or App Store Connect API key secrets."
-          exit 65
+          set -euo pipefail
+          missing=()
+          [ -n "${{ secrets.IOS_CERT_P12 }}" ] || missing+=(IOS_CERT_P12)
+          [ -n "${{ secrets.IOS_PROFILE }}" ] || missing+=(IOS_PROFILE)
+          [ -n "${{ secrets.IOS_CERT_PASSWORD }}" ] || missing+=(IOS_CERT_PASSWORD)
+          [ ${#missing[@]} -eq 0 ] || { echo "::error::Missing signing secrets: ${missing[*]}"; exit 65; }
 
       # === CODE SIGNING: install cert & profile into a temp keychain ===
       - name: Install signing cert & profile
-        if: steps.signing.outputs.mode == 'manual'
         shell: bash
         env:
           P12_B64: ${{ secrets.IOS_CERT_P12 }}
@@ -129,12 +120,6 @@ jobs:
 
           KEYCHAIN="build/signing.keychain-db"
           KEYCHAIN_PWD="$(openssl rand -hex 16)"
-
-          cleanup() {
-            security delete-keychain "$KEYCHAIN" >/dev/null 2>&1 || true
-            rm -rf signing
-          }
-          trap cleanup EXIT
 
           security create-keychain -p "$KEYCHAIN_PWD" "$KEYCHAIN"
           security set-keychain-settings -lut 7200 "$KEYCHAIN"
@@ -151,36 +136,26 @@ jobs:
           fi
           echo "Using signing identity: $CERT_ID"
 
-          UUID=$(/usr/libexec/PlistBuddy -c 'Print UUID' /dev/stdin <<<"$(security cms -D -i signing/profile.mobileprovision)")
+          PROFILE_PLIST=$(mktemp)
+          security cms -D -i signing/profile.mobileprovision > "$PROFILE_PLIST"
+          UUID=$(/usr/libexec/PlistBuddy -c 'Print UUID' "$PROFILE_PLIST")
+          PROFILE_NAME=$(/usr/libexec/PlistBuddy -c 'Print Name' "$PROFILE_PLIST")
+
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
           cp signing/profile.mobileprovision ~/Library/MobileDevice/Provisioning\ Profiles/$UUID.mobileprovision
-          echo "Installed profile UUID: $UUID"
+          echo "Installed profile UUID: $UUID (name: $PROFILE_NAME)"
 
           {
             echo "CERT_ID=$CERT_ID"
+            echo "PROFILE_NAME=$PROFILE_NAME"
             echo "PROFILE_UUID=$UUID"
             echo "KEYCHAIN=$KEYCHAIN"
             echo "KEYCHAIN_PWD=$KEYCHAIN_PWD"
           } >> $GITHUB_ENV
 
-      - name: Configure App Store Connect API key
-        if: steps.signing.outputs.mode == 'api'
-        env:
-          APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
-          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_API_KEY_ISSUER: ${{ secrets.APPLE_API_KEY_ISSUER }}
-        run: |
-          set -euo pipefail
-          mkdir -p build/signing
-          echo "$APPLE_API_PRIVATE_KEY" | base64 --decode > build/signing/AuthKey.p8
-          {
-            echo "APP_STORE_CONNECT_API_KEY_PATH=$PWD/build/signing/AuthKey.p8"
-            echo "APP_STORE_CONNECT_API_KEY_ID=$APPLE_API_KEY_ID"
-            echo "APP_STORE_CONNECT_API_KEY_ISSUER=$APPLE_API_KEY_ISSUER"
-          } >> $GITHUB_ENV
+          rm -f "$PROFILE_PLIST"
 
       - name: Xcode archive (manual signing)
-        if: steps.signing.outputs.mode == 'manual'
         shell: bash
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -196,32 +171,9 @@ jobs:
             -archivePath "$ARCHIVE_PATH" \
             DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
             PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
-            PROVISIONING_PROFILE_SPECIFIER="$PROFILE_UUID" \
+            CODE_SIGN_STYLE=Manual \
+            PROVISIONING_PROFILE_SPECIFIER="$PROFILE_NAME" \
             CODE_SIGN_IDENTITY="$CERT_ID" \
-            archive | tee build/archive.log
-          test ${PIPESTATUS[0]} -eq 0
-
-      - name: Xcode archive (automatic signing)
-        if: steps.signing.outputs.mode == 'api'
-        shell: bash
-        env:
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: |
-          set -euo pipefail
-          mkdir -p build
-          xcodebuild \
-            -workspace "$WORKSPACE" \
-            -scheme "$SCHEME" \
-            -configuration "$CONFIG" \
-            -sdk iphoneos \
-            -destination 'generic/platform=iOS' \
-            -archivePath "$ARCHIVE_PATH" \
-            DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
-            PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
-            -allowProvisioningUpdates \
-            -authenticationKeyPath "$APP_STORE_CONNECT_API_KEY_PATH" \
-            -authenticationKeyID "$APP_STORE_CONNECT_API_KEY_ID" \
-            -authenticationKeyIssuerID "$APP_STORE_CONNECT_API_KEY_ISSUER" \
             archive | tee build/archive.log
           test ${PIPESTATUS[0]} -eq 0
 
@@ -240,7 +192,6 @@ jobs:
           codesign -d --entitlements :- "$APP_PATH" 2>/dev/null | plutil -convert json -o - - | jq '{application_identifier,com.apple.developer.team-identifier}' | tee build/entitlements.json
 
       - name: Export IPA (manual signing)
-        if: steps.signing.outputs.mode == 'manual'
         shell: bash
         run: |
           set -euo pipefail
@@ -252,7 +203,7 @@ jobs:
             <key>uploadSymbols</key><true/>
             <key>signingStyle</key><string>manual</string>
             <key>provisioningProfiles</key><dict>
-              <key>com.apex.tradeline</key><string>TL247_mobpro_tradeline_01</string>
+              <key>com.apex.tradeline</key><string>$PROFILE_NAME</string>
             </dict>
           </dict></plist>
           PLIST
@@ -263,37 +214,6 @@ jobs:
           IPA=$(ls "$EXPORT_PATH"/*.ipa | head -n1)
           echo "IPA_PATH=$IPA" >> $GITHUB_ENV
           echo "Exported: $IPA"
-
-      - name: Export IPA (automatic signing)
-        if: steps.signing.outputs.mode == 'api'
-        shell: bash
-        run: |
-          set -euo pipefail
-          cat > ExportOptions.plist <<'PLIST'
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0"><dict>
-            <key>method</key><string>app-store</string>
-            <key>uploadSymbols</key><true/>
-            <key>signingStyle</key><string>automatic</string>
-          </dict></plist>
-          PLIST
-          xcodebuild -exportArchive \
-            -archivePath "$ARCHIVE_PATH" \
-            -exportPath "$EXPORT_PATH" \
-            -exportOptionsPlist ExportOptions.plist \
-            -allowProvisioningUpdates \
-            -authenticationKeyPath "$APP_STORE_CONNECT_API_KEY_PATH" \
-            -authenticationKeyID "$APP_STORE_CONNECT_API_KEY_ID" \
-            -authenticationKeyIssuerID "$APP_STORE_CONNECT_API_KEY_ISSUER" | tee build/export.log
-          IPA=$(ls "$EXPORT_PATH"/*.ipa | head -n1)
-          echo "IPA_PATH=$IPA" >> $GITHUB_ENV
-          echo "Exported: $IPA"
-
-      - name: Clean temporary API key
-        if: steps.signing.outputs.mode == 'api'
-        run: |
-          rm -f "$APP_STORE_CONNECT_API_KEY_PATH" || true
 
       - name: Upload to App Store Connect (Transporter)
         shell: bash
@@ -311,6 +231,16 @@ jobs:
             -apiIssuer "$ASC_ISSUER_ID" \
             -authenticationKeyPath api_key.p8
           rm -f api_key.p8
+
+      - name: Clean up signing assets
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ -n "${KEYCHAIN:-}" ]; then
+            security delete-keychain "$KEYCHAIN" >/dev/null 2>&1 || true
+          fi
+          rm -f "${HOME}/Library/MobileDevice/Provisioning Profiles/${PROFILE_UUID:-}.mobileprovision"
+          rm -rf signing
 
       - name: Upload artifacts (IPA + logs)
         if: always()


### PR DESCRIPTION
## Summary
- enforce a single manual signing path in the release iOS workflow and remove the automatic branch
- capture provisioning profile details for manual archive/export and validate required signing secrets
- add cleanup for temporary signing assets after upload

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69263e1635d4832da90bf81cca737a91)