### PR TITLE
Fix iOS signing conflict causing 401 authentication errors

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -16,12 +16,6 @@ workflows:
 
         - appstore_credentials
 
-      ios_signing:
-
-        distribution_type: app_store
-
-        bundle_identifier: com.apex.tradeline
-
       vars:
 
         XCODE_SCHEME: App


### PR DESCRIPTION
- Remove ios_signing block that conflicts with manual signing scripts
- Manual signing approach (keychain + xcrun altool) handles all authentication
- Eliminates double authentication attempts that cause 401 errors
- Build now uses consistent CODE_SIGN_STYLE=Manual throughout

## Changes

<!-- Brief description of what changed -->

## React Hooks Checklist (H310-8)

- [ ] All hooks are at top-level (no conditional/looped hooks)
- [ ] No component function calls (e.g., `Component()` → use `<Component/>`)
- [ ] No early returns before hooks complete
- [ ] ESLint passes with zero hook warnings

## Evidence

## Supabase Auth URL Configuration

- [ ] Site URL set to production domain in Supabase Auth settings
- [ ] Redirect URLs cover magic-link and password-reset flows (HTTPS, no stray trailing slashes)

- [ ] Evidence attached (links to `/ops/twilio-evidence` or test results)
- [ ] Synthetic-smoke passing ([latest run](https://github.com/apex-business-systems/tradeline247/actions/workflows/synthetic-smoke.yml))
- [ ] Twilio Debugger webhook targets `ops-twilio-debugger-intake` (HTTPS)
- [ ] No new secrets in repo (all secrets go to GitHub environments)
- [ ] Store disclosure unchanged or updated (if applicable)

## Testing

<!-- How was this tested? -->

## Deployment Notes

<!-- Any special deployment considerations? -->

---

**For Ops Incidents:** Include CallSid/MessageSid, endpoint, timestamp, and [Twilio Debugger](https://console.twilio.com/us1/monitor/debugger) link.

