### PR TITLE
Remove debug start script from codemagic.yaml

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1,21 +1,3 @@
-- name: Debug start — verify scripts execute
-  script: |
-    set -e
-    echo "==== Debug start: CM_BUILD_DIR=$CM_BUILD_DIR ===="
-    echo "Workflow: $CM_WORKFLOW_ID"
-    echo "---- env vars (filtered) ----"
-    env | grep -E 'BUNDLE_ID|TEAM_ID|XCODE_WORKSPACE|XCODE_SCHEME|APP_VERSION|APP_BUILD' || true
-    echo "---- top-level repo listing ----"
-    pwd
-    ls -la
-    echo "---- ios listing ----"
-    ls -la ios || true
-    echo "---- ios/App listing ----"
-    ls -la ios/App || true
-    echo "---- package.json head ----"
-    head -n 30 package.json || true
-    echo "==== Debug end ===="
-
 workflows:
   ios_capacitor_testflight:
     name: iOS - Capacitor -> TestFlight (single run)


### PR DESCRIPTION
Removed debug script from Codemagic workflow.

## Changes

<!-- Brief description of what changed -->

## React Hooks Checklist (H310-8)

- [ ] All hooks are at top-level (no conditional/looped hooks)
- [ ] No component function calls (e.g., `Component()` → use `<Component/>`)
- [ ] No early returns before hooks complete
- [ ] ESLint passes with zero hook warnings

## Evidence

## Supabase Auth URL Configuration

- [ ] Site URL set to production domain in Supabase Auth settings
- [ ] Redirect URLs cover magic-link and password-reset flows (HTTPS, no stray trailing slashes)

- [ ] Evidence attached (links to `/ops/twilio-evidence` or test results)
- [ ] Synthetic-smoke passing ([latest run](https://github.com/apex-business-systems/tradeline247/actions/workflows/synthetic-smoke.yml))
- [ ] Twilio Debugger webhook targets `ops-twilio-debugger-intake` (HTTPS)
- [ ] No new secrets in repo (all secrets go to GitHub environments)
- [ ] Store disclosure unchanged or updated (if applicable)

## Testing

<!-- How was this tested? -->

## Deployment Notes

<!-- Any special deployment considerations? -->

---

**For Ops Incidents:** Include CallSid/MessageSid, endpoint, timestamp, and [Twilio Debugger](https://console.twilio.com/us1/monitor/debugger) link.

