### PR TITLE
fix: resolve YAML structure error and configure internal-only TestFli…

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -108,22 +108,6 @@ workflows:
 
 
 
-    publishing:
-
-      app_store_connect:
-
-        api_key: $APP_STORE_CONNECT_PRIVATE_KEY
-
-        key_id: $APP_STORE_CONNECT_KEY_IDENTIFIER
-
-        issuer_id: $APP_STORE_CONNECT_ISSUER_ID
-
-        # Upload only - do not submit for TestFlight beta review
-
-        submit_to_testflight: false
-
-
-
       - name: Verify artifacts
 
         script: bash scripts/verify-codemagic.sh
@@ -142,6 +126,20 @@ workflows:
 
       - build-artifacts-sha256.txt
 
+
+    publishing:
+
+      app_store_connect:
+
+        api_key: $APP_STORE_CONNECT_PRIVATE_KEY
+
+        key_id: $APP_STORE_CONNECT_KEY_IDENTIFIER
+
+        issuer_id: $APP_STORE_CONNECT_ISSUER_ID
+
+        # Upload only - do not submit for TestFlight beta review
+
+        submit_to_testflight: false
 
 
     triggering:


### PR DESCRIPTION
…ght uploads

- Fix YAML parsing error by moving 'Verify artifacts' step from publishing to scripts section
- Restore publishing.app_store_connect block with authentication keys
- Explicitly set submit_to_testflight: false to prevent automatic beta review submission
- Ensure proper section hierarchy: environment -> scripts -> artifacts -> publishing -> triggering
- Enable manual internal TestFlight distribution through App Store Connect UI

## Changes

<!-- Brief description of what changed -->

## React Hooks Checklist (H310-8)

- [ ] All hooks are at top-level (no conditional/looped hooks)
- [ ] No component function calls (e.g., `Component()` → use `<Component/>`)
- [ ] No early returns before hooks complete
- [ ] ESLint passes with zero hook warnings

## Evidence

## Supabase Auth URL Configuration

- [ ] Site URL set to production domain in Supabase Auth settings
- [ ] Redirect URLs cover magic-link and password-reset flows (HTTPS, no stray trailing slashes)

- [ ] Evidence attached (links to `/ops/twilio-evidence` or test results)
- [ ] Synthetic-smoke passing ([latest run](https://github.com/apex-business-systems/tradeline247/actions/workflows/synthetic-smoke.yml))
- [ ] Twilio Debugger webhook targets `ops-twilio-debugger-intake` (HTTPS)
- [ ] No new secrets in repo (all secrets go to GitHub environments)
- [ ] Store disclosure unchanged or updated (if applicable)

## Testing

<!-- How was this tested? -->

## Deployment Notes

<!-- Any special deployment considerations? -->

---

**For Ops Incidents:** Include CallSid/MessageSid, endpoint, timestamp, and [Twilio Debugger](https://console.twilio.com/us1/monitor/debugger) link.

