### PR TITLE
Disable automatic TestFlight submission for iOS workflow

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -136,11 +136,13 @@ workflows:
 
         issuer_id: $APP_STORE_CONNECT_ISSUER_ID
 
-        submit_to_testflight: true
+        # Internal-only distribution: upload without automatic TestFlight submission.
 
-        beta_groups:
+        # submit_to_testflight: true
 
-          - Internal Testers
+        # beta_groups:
+
+        #   - Internal Testers
 
 
     triggering:


### PR DESCRIPTION
## Summary
- adjust Codemagic iOS publishing to only upload to App Store Connect without auto-submitting to TestFlight
- retain existing App Store Connect credentials while commenting out TestFlight submission settings

## Testing
- Not run (CI configuration change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692949df0e20832da41d0c3981c96903)