### PR TITLE
Move dashboard greeting into avatar menu

### DIFF
--- a/src/components/dashboard/NewDashboard.tsx
+++ b/src/components/dashboard/NewDashboard.tsx
@@ -23,7 +23,6 @@ import { useUserPreferencesStore } from '@/stores/userPreferencesStore';
 import { useDashboardStore } from '@/stores/dashboardStore';
 import { PersonalizedWelcomeDialog } from './PersonalizedWelcomeDialog';
 import { PersonalizedTips } from './PersonalizedTips';
-import { WelcomeHeader } from './new/WelcomeHeader';
 
 export const NewDashboard = () => {
   const { kpis, nextItems, transcripts, isLoading, hasData } = useDashboardData();
@@ -88,9 +87,6 @@ export const NewDashboard = () => {
   return (
     <>
       <div className={spacingClass}>
-        {/* Welcome Header */}
-        <WelcomeHeader />
-
         {/* KPI Cards */}
         <div className={`grid grid-cols-2 md:grid-cols-4 ${gridGapClass}`}>
         {isLoading ? (

--- a/src/components/dashboard/__tests__/NewDashboard.test.tsx
+++ b/src/components/dashboard/__tests__/NewDashboard.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { NewDashboard } from '../NewDashboard';
+
+vi.mock('@/hooks/useDashboardData', () => ({
+  useDashboardData: () => ({
+    kpis: [],
+    nextItems: [],
+    transcripts: [],
+    isLoading: false,
+    hasData: false,
+    error: null,
+    lastUpdated: null,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock('@/stores/userPreferencesStore', () => ({
+  useUserPreferencesStore: () => ({
+    hasCompletedOnboarding: true,
+    dashboardLayout: 'comfortable',
+    showQuickActions: true,
+    showServiceHealth: true,
+    showRecentActivity: false,
+    showWelcomeMessage: false,
+  }),
+}));
+
+vi.mock('@/stores/dashboardStore', () => ({
+  useDashboardStore: () => ({
+    isWelcomeDialogOpen: false,
+    setWelcomeDialogOpen: vi.fn(),
+  }),
+}));
+
+vi.mock('../new/NextActionsSection', () => ({ NextActionsSection: () => <div data-testid="next-actions" /> }));
+vi.mock('../new/WinsSection', () => ({ WinsSection: () => <div data-testid="wins-section" /> }));
+vi.mock('../QuickActionsCard', () => ({ QuickActionsCard: () => <div data-testid="quick-actions" /> }));
+vi.mock('../ServiceHealth', () => ({ ServiceHealth: () => <div data-testid="service-health" /> }));
+vi.mock('../PersonalizedTips', () => ({ PersonalizedTips: () => <div data-testid="personalized-tips" /> }));
+vi.mock('../PersonalizedWelcomeDialog', () => ({ PersonalizedWelcomeDialog: () => null }));
+vi.mock('../components/KpiCard', () => ({ KpiCard: ({ kpi }: { kpi: { id: string } }) => <div data-testid={`kpi-${kpi.id}`} /> }));
+
+describe('NewDashboard layout', () => {
+  it('does not render the greeting strip inside the dashboard content', () => {
+    render(<NewDashboard />);
+
+    expect(screen.queryByTestId('welcome-header')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
-import { NavigationMenu, NavigationMenuContent, NavigationMenuItem, NavigationMenuLink, NavigationMenuList } from '@/components/ui/navigation-menu';
-import { Menu, X, LogOut, User, Settings, ChevronDown, Phone, Smartphone } from 'lucide-react';
+import { NavigationMenu, NavigationMenuItem, NavigationMenuLink, NavigationMenuList } from '@/components/ui/navigation-menu';
+import { Menu, X, LogOut, User, Settings, Phone, Smartphone } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/hooks/useAuth';
 import { Link, useLocation } from 'react-router-dom';
@@ -10,6 +10,7 @@ import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 import { useSafeNavigation } from '@/hooks/useSafeNavigation';
 import { errorReporter } from '@/lib/errorReporter';
 import builtCanadianBadge from '@/assets/badges/built-canadian.svg';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -18,6 +19,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { useUserPreferencesStore } from '@/stores/userPreferencesStore';
 // CSS import removed in main branch - keeping defensive approach
 
 // Navigation configuration
@@ -40,6 +42,7 @@ const ADMIN_NAV = [
 export const Header: React.FC = () => {
   const [isScrolled, setIsScrolled] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
   // Defensive hook calls with fallbacks for enterprise-grade resilience
   const {
     user = null,
@@ -49,11 +52,16 @@ export const Header: React.FC = () => {
   } = useAuth() || {};
 
   const { goToWithFeedback = async (path: string) => { window.location.href = path; } } = useSafeNavigation() || {};
+  const { preferredName, showWelcomeMessage } = useUserPreferencesStore();
 
   const location = useLocation();
   const mobileMenuId = 'mobile-menu';
   const isUserAdmin = typeof isAdmin === 'function' ? isAdmin() : false;
   const isMarketingHome = location?.pathname === paths.home;
+
+  useEffect(() => {
+    setIsUserMenuOpen(false);
+  }, [location?.pathname]);
 
   // Streamlined navigation handler - single source of truth with enterprise error handling
   const handleNavigation = React.useCallback(async (href: string, label: string, closeMenu = false) => {
@@ -86,6 +94,13 @@ export const Header: React.FC = () => {
       window.location.href = paths.home;
     }
   }, [signOut]);
+
+  const getGreeting = useCallback(() => {
+    const hour = new Date().getHours();
+    if (hour < 12) return 'Good morning';
+    if (hour < 18) return 'Good afternoon';
+    return 'Good evening';
+  }, []);
 
   // Optimized scroll handler
   useEffect(() => {
@@ -134,7 +149,14 @@ export const Header: React.FC = () => {
   }, [location?.pathname]);
 
   // User display name with defensive checks
-  const userDisplayName = user?.user_metadata?.display_name || user?.email?.split('@')[0] || 'User';
+  const displayName = preferredName
+    || user?.user_metadata?.full_name
+    || user?.user_metadata?.display_name
+    || user?.email?.split('@')[0]
+    || 'User';
+  const greetingMessage = showWelcomeMessage ? `${getGreeting()}, ${displayName}` : null;
+  const avatarUrl = (user?.user_metadata as { avatar_url?: string } | undefined)?.avatar_url;
+  const avatarInitials = displayName.charAt(0).toUpperCase();
 
   return (
     <header
@@ -281,35 +303,46 @@ export const Header: React.FC = () => {
           {user ? (
             <>
               {/* Desktop: User Dropdown */}
-              <DropdownMenu>
+              <DropdownMenu open={isUserMenuOpen} onOpenChange={setIsUserMenuOpen}>
                 <DropdownMenuTrigger asChild>
                   <Button
                     variant="ghost"
                     size={isScrolled ? 'sm' : 'default'}
-                    className="hidden lg:flex items-center gap-2 hover:bg-accent transition-all duration-300"
+                    className="flex items-center gap-2 hover:bg-accent transition-all duration-300 focus-visible:ring-2 focus-visible:ring-ring"
+                    aria-label="Open user menu"
+                    aria-haspopup="menu"
+                    aria-expanded={isUserMenuOpen}
                   >
-                    <div className="flex flex-col items-start">
-                      <span className="text-sm font-medium text-foreground leading-tight">
-                        {userDisplayName}
-                      </span>
-                      {userRole && (
-                        <span className={cn(
-                          'text-xs font-medium leading-tight',
-                          isUserAdmin ? 'text-red-600 dark:text-red-400' : 'text-blue-600 dark:text-blue-400'
-                        )}>
-                          {userRole.toUpperCase()}
-                        </span>
-                      )}
-                    </div>
-                    <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                    <Avatar className="h-9 w-9">
+                      {avatarUrl ? (
+                        <AvatarImage src={avatarUrl} alt={`${displayName} avatar`} />
+                      ) : null}
+                      <AvatarFallback aria-hidden="true">{avatarInitials}</AvatarFallback>
+                    </Avatar>
                   </Button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-56">
-                  <DropdownMenuLabel>
-                    <div className="flex flex-col space-y-1">
-                      <p className="text-sm font-medium">{userDisplayName}</p>
-                      <p className="text-xs text-muted-foreground">{user?.email}</p>
-                    </div>
+                <DropdownMenuContent
+                  align="end"
+                  className="w-64 origin-top-right data-[state=open]:animate-none data-[state=closed]:animate-none transition-[opacity,transform] duration-200 ease-in-out data-[state=open]:opacity-100 data-[state=closed]:opacity-0 data-[state=open]:scale-100 data-[state=closed]:scale-95"
+                >
+                  <DropdownMenuLabel className="space-y-1" data-testid="avatar-menu-greeting">
+                    {greetingMessage && (
+                      <p className="text-xs text-muted-foreground">{greetingMessage}</p>
+                    )}
+                    <p className="text-sm font-semibold">{displayName}</p>
+                    {user?.email && (
+                      <p className="text-xs text-muted-foreground break-all">{user.email}</p>
+                    )}
+                    {userRole && (
+                      <span
+                        className={cn(
+                          'text-xs font-medium leading-tight',
+                          isUserAdmin ? 'text-red-600 dark:text-red-400' : 'text-blue-600 dark:text-blue-400'
+                        )}
+                      >
+                        {userRole.toUpperCase()}
+                      </span>
+                    )}
                   </DropdownMenuLabel>
                   {isUserAdmin && (
                     <>

--- a/src/components/layout/__tests__/Header.test.tsx
+++ b/src/components/layout/__tests__/Header.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Header } from '../Header';
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: {
+      email: 'jr@example.com',
+      user_metadata: { display_name: 'JR Test', avatar_url: 'avatar.png' },
+    },
+    userRole: 'user',
+    signOut: vi.fn(),
+    isAdmin: () => false,
+  }),
+}));
+
+vi.mock('@/hooks/useSafeNavigation', () => ({
+  useSafeNavigation: () => ({ goToWithFeedback: vi.fn() }),
+}));
+
+vi.mock('@/components/LanguageSwitcher', () => ({
+  LanguageSwitcher: () => <button aria-label="language switcher" />,
+}));
+
+vi.mock('@/assets/badges/built-canadian.svg', () => ({ default: 'badge.svg' }));
+
+vi.mock('@/stores/userPreferencesStore', () => ({
+  useUserPreferencesStore: () => ({
+    preferredName: 'JR',
+    showWelcomeMessage: true,
+  }),
+}));
+
+describe('Header user menu', () => {
+  let hourSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    hourSpy = vi.spyOn(Date.prototype, 'getHours').mockReturnValue(9);
+  });
+
+  afterEach(() => {
+    hourSpy.mockRestore();
+  });
+
+  it('moves the greeting into the avatar menu and closes on Escape', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>
+    );
+
+    const trigger = screen.getByLabelText(/open user menu/i);
+    await user.click(trigger);
+
+    expect(await screen.findByText(/good morning, jr/i)).toBeInTheDocument();
+    expect(screen.getByText('jr@example.com')).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByText(/good morning, jr/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -990,7 +990,7 @@ textarea:focus-visible {
 }
 
 /* Sticky header positioning */
-header {
+[data-site-header] {
   position: sticky;
   top: 0;
   z-index: 50;


### PR DESCRIPTION
## Summary
- scope sticky styling to the site header and remove the dashboard welcome strip from the scrollable content
- surface the personalized greeting inside a keyboard-accessible avatar dropdown with animated open/close behavior
- add coverage to ensure the greeting strip is absent on the dashboard and the avatar menu shows the greeting

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692bb5f868d8832da7cd0552a31ef527)