### PR TITLE
Add hero-scoped wallpaper and swipe navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite_react_shadcn_ts",
-  "version": "0.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite_react_shadcn_ts",
-      "version": "0.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@capacitor/cli": "^7.4.3",
         "@capacitor/core": "^7.4.3",
@@ -56,6 +56,7 @@
         "react-i18next": "^16.0.0",
         "react-resizable-panels": "^2.1.9",
         "react-router-dom": "^7.9.4",
+        "react-swipeable": "^7.0.2",
         "recharts": "^3.5.0",
         "sonner": "^1.7.4",
         "tailwind-merge": "^2.6.0",
@@ -12036,6 +12037,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-swipeable": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-7.0.2.tgz",
+      "integrity": "sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "react-i18next": "^16.0.0",
     "react-resizable-panels": "^2.1.9",
     "react-router-dom": "^7.9.4",
+    "react-swipeable": "^7.0.2",
     "recharts": "^3.5.0",
     "sonner": "^1.7.4",
     "tailwind-merge": "^2.6.0",

--- a/src/components/layout/SwipeLayout.tsx
+++ b/src/components/layout/SwipeLayout.tsx
@@ -1,0 +1,89 @@
+import React, { useMemo, useRef } from "react";
+import { useSwipeable } from "react-swipeable";
+import { cn } from "@/lib/utils";
+
+interface SwipeLayoutProps {
+  children: React.ReactNode;
+  className?: string;
+  sectionClassName?: string;
+}
+
+export const SwipeLayout: React.FC<SwipeLayoutProps> = ({
+  children,
+  className,
+  sectionClassName,
+}) => {
+  const sectionRefs = useRef<(HTMLElement | null)[]>([]);
+  const sections = useMemo(() => React.Children.toArray(children), [children]);
+
+  const scrollToSection = (index: number) => {
+    const target = sectionRefs.current[index];
+
+    if (target) {
+      target.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  };
+
+  const getCurrentSectionIndex = () => {
+    const viewportMidpoint = window.innerHeight / 2;
+    let closestIndex = 0;
+    let closestDistance = Number.POSITIVE_INFINITY;
+
+    sectionRefs.current.forEach((section, index) => {
+      if (!section) return;
+
+      const rect = section.getBoundingClientRect();
+      const sectionMidpoint = rect.top + rect.height / 2;
+      const distance = Math.abs(sectionMidpoint - viewportMidpoint);
+
+      if (distance < closestDistance) {
+        closestDistance = distance;
+        closestIndex = index;
+      }
+    });
+
+    return closestIndex;
+  };
+
+  const handlers = useSwipeable({
+    onSwipedUp: () => {
+      const currentIndex = getCurrentSectionIndex();
+
+      if (currentIndex < sections.length - 1) {
+        scrollToSection(currentIndex + 1);
+      }
+    },
+    onSwipedDown: () => {
+      const currentIndex = getCurrentSectionIndex();
+
+      if (currentIndex > 0) {
+        scrollToSection(currentIndex - 1);
+      }
+    },
+    preventScrollOnSwipe: true,
+    trackTouch: true,
+    trackMouse: false,
+  });
+
+  return (
+    <div
+      className={cn("relative w-full touch-pan-y", className)}
+      {...handlers}
+      aria-label="Swipe layout container"
+    >
+      {sections.map((child, index) => (
+        <section
+          key={index}
+          ref={(element) => {
+            sectionRefs.current[index] = element;
+          }}
+          className={cn("swipe-section", sectionClassName)}
+        >
+          {child}
+        </section>
+      ))}
+    </div>
+  );
+};
+
+export default SwipeLayout;

--- a/src/index.css
+++ b/src/index.css
@@ -32,44 +32,32 @@
   overflow: hidden;
 }
 
-.hero-background::before {
-  content: "";
+.hero-gradient-tint {
   position: absolute;
   inset: 0;
-  z-index: -1;
   background-image:
     linear-gradient(to bottom, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0.14)),
     linear-gradient(
       to bottom,
       rgba(255, 107, 53, 0.62) 0%,
       rgba(104, 182, 233, 0.72) 100%
-    ),
-    var(--landing-wallpaper, none);
-  background-position: center top, center top, center top;
-  background-repeat: no-repeat, no-repeat, no-repeat;
-  /* Keep gradients covering the hero band while letting the wallpaper stay fully in-frame */
-  background-size: cover, cover, cover;
-  /* Keep the wallpaper pinned in place across platforms */
-  background-attachment: fixed, fixed, fixed;
-  will-change: transform;
+    );
+  background-position: center top, center top;
+  background-repeat: no-repeat, no-repeat;
+  background-size: cover, cover;
+  pointer-events: none;
+  z-index: 0;
 }
 
 @media (max-width: 1024px) {
-  .hero-background::before {
-    background-position: center 10%, center 10%, center 10%;
+  .hero-gradient-tint {
+    background-position: center 10%, center 10%;
   }
 }
 
 @media (max-width: 640px) {
-  .hero-background::before {
-    background-position: center 14%, center 14%, center 14%;
-  }
-}
-
-/* iOS fallback: maintain stationary effect without fixed attachment glitches */
-@supports (-webkit-touch-callout: none) {
-  .hero-background::before {
-    background-attachment: fixed !important;
+  .hero-gradient-tint {
+    background-position: center 14%, center 14%;
   }
 }
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -13,6 +13,7 @@ import backgroundImage from "@/assets/BACKGROUND_IMAGE1.svg";
 import { QuickActionsCard } from "@/components/dashboard/QuickActionsCard";
 import { errorReporter } from "@/lib/errorReporter";
 import SwipeNavigator from "@/components/layout/SwipeNavigator";
+import SwipeLayout from "@/components/layout/SwipeLayout";
 
 const Index = () => {
   const { trackPageView } = useAnalytics();
@@ -39,16 +40,11 @@ const Index = () => {
   }, []);
 
   const wallpaperStyle = {
-    // Keeps the wallpaper constrained to the hero wrapper only
-    "--landing-wallpaper": `url(${backgroundImage})`,
+    backgroundImage: `url(${backgroundImage})`,
   } as CSSProperties;
 
   const landingBackgroundStyle = {
     backgroundColor: "hsl(0, 0%, 97%)", // Fallback color if image fails (light gray)
-    backgroundImage: `url(${backgroundImage})`,
-    backgroundRepeat: "no-repeat",
-    backgroundPosition: "center top",
-    backgroundSize: "cover",
   } as CSSProperties;
 
   return (
@@ -58,75 +54,80 @@ const Index = () => {
         className="landing-shell min-h-screen flex flex-col relative"
         style={landingBackgroundStyle}
       >
-          {/* Content with translucency - Optimized for performance */}
-          <div className="relative z-10" style={{ minHeight: "100vh" }}>
-            <AISEOHead
-              title="TradeLine 24/7 - Your 24/7 AI Receptionist!"
-              description="Get fast and reliable customer service that never sleeps. Handle calls, messages, and inquiries 24/7 with human-like responses. Start growing now!"
-              canonical="/"
-              contentType="service"
-              directAnswer="TradeLine 24/7 is an AI-powered receptionist service that answers phone calls 24/7, qualifies leads, and sends clean transcripts via email to Canadian businesses. Never miss a call. Work while you sleep."
-              primaryEntity={{
-                name: "TradeLine 24/7 AI Receptionist Service",
-                type: "Service",
-                description: "24/7 AI-powered phone answering service for Canadian businesses",
-              }}
-              keyFacts={[
-                { label: "Availability", value: "24/7" },
-                { label: "Response Time", value: "<2 seconds" },
-                { label: "Uptime", value: "99.9%" },
-                { label: "Service Area", value: "Canada" },
-              ]}
-              faqs={[
-                {
-                  question: "What is TradeLine 24/7?",
-                  answer:
-                    "TradeLine 24/7 is an AI-powered receptionist service that answers phone calls 24/7, qualifies leads based on your criteria, and sends clean email transcripts. It never misses a call and works while you sleep.",
-                },
-                {
-                  question: "How does TradeLine 24/7 work?",
-                  answer:
-                    "When a call comes in, our AI answers immediately, has a natural conversation with the caller, qualifies them based on your criteria, and sends you a clean email transcript with all the details.",
-                },
-                {
-                  question: "What areas does TradeLine 24/7 serve?",
-                  answer:
-                    "TradeLine 24/7 serves businesses across Canada, with primary operations in Edmonton, Alberta.",
-                },
-                {
-                  question: "How much does TradeLine 24/7 cost?",
-                  answer:
-                    "TradeLine 24/7 offers flexible pricing: $149 CAD per qualified appointment (pay-per-use) or $249 CAD per month for the Predictable Plan.",
-                },
-              ]}
-            />
+        {/* Content with translucency - Optimized for performance */}
+        <div className="relative z-10" style={{ minHeight: "100vh" }}>
+          <AISEOHead
+            title="TradeLine 24/7 - Your 24/7 AI Receptionist!"
+            description="Get fast and reliable customer service that never sleeps. Handle calls, messages, and inquiries 24/7 with human-like responses. Start growing now!"
+            canonical="/"
+            contentType="service"
+            directAnswer="TradeLine 24/7 is an AI-powered receptionist service that answers phone calls 24/7, qualifies leads based on your criteria, and sends clean email transcripts to Canadian businesses. Never miss a call. Work while you sleep."
+            primaryEntity={{
+              name: "TradeLine 24/7 AI Receptionist Service",
+              type: "Service",
+              description: "24/7 AI-powered phone answering service for Canadian businesses",
+            }}
+            keyFacts={[
+              { label: "Availability", value: "24/7" },
+              { label: "Response Time", value: "<2 seconds" },
+              { label: "Uptime", value: "99.9%" },
+              { label: "Service Area", value: "Canada" },
+            ]}
+            faqs={[
+              {
+                question: "What is TradeLine 24/7?",
+                answer:
+                  "TradeLine 24/7 is an AI-powered receptionist service that answers phone calls 24/7, qualifies leads based on your criteria, and sends clean email transcripts. It never misses a call and works while you sleep.",
+              },
+              {
+                question: "How does TradeLine 24/7 work?",
+                answer:
+                  "When a call comes in, our AI answers immediately, has a natural conversation with the caller, qualifies them based on your criteria, and sends you a clean email transcript with all the details.",
+              },
+              {
+                question: "What areas does TradeLine 24/7 serve?",
+                answer:
+                  "TradeLine 24/7 serves businesses across Canada, with primary operations in Edmonton, Alberta.",
+              },
+              {
+                question: "How much does TradeLine 24/7 cost?",
+                answer:
+                  "TradeLine 24/7 offers flexible pricing: $149 CAD per qualified appointment (pay-per-use) or $249 CAD per month for the Predictable Plan.",
+              },
+            ]}
+          />
 
-            <div className="flex-1" style={{ minHeight: "60vh" }}>
-              <div className="hero-background" style={wallpaperStyle}>
-                <HeroRoiDuo />
-              </div>
-              <BenefitsGrid />
-              <ImpactStrip />
-              <HowItWorks />
-              <div className="container mx-auto px-4 py-12">
-                <div className="mx-auto max-w-4xl space-y-6 text-center">
-                  <h2 className="text-2xl font-semibold tracking-tight text-foreground">
-                    Quick actions for operators
-                  </h2>
-                  <p className="text-muted-foreground">
-                    Jump straight into the workflows you use every day. These shortcuts survive refreshes and deep links.
-                  </p>
-                  <QuickActionsCard />
-                </div>
+          <SwipeLayout sectionClassName="justify-start">
+            <div className="hero-background relative">
+              <div
+                id="hero-background-wrapper"
+                className="absolute inset-0 bg-cover bg-center bg-no-repeat pointer-events-none"
+                style={wallpaperStyle}
+                aria-hidden="true"
+              />
+              <div className="hero-gradient-tint" aria-hidden="true" />
+              <HeroRoiDuo />
+            </div>
+            <BenefitsGrid />
+            <ImpactStrip />
+            <HowItWorks />
+            <div className="container mx-auto px-4 py-12">
+              <div className="mx-auto max-w-4xl space-y-6 text-center">
+                <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+                  Quick actions for operators
+                </h2>
+                <p className="text-muted-foreground">
+                  Jump straight into the workflows you use every day. These shortcuts survive refreshes and deep links.
+                </p>
+                <QuickActionsCard />
               </div>
             </div>
-
             <TrustBadgesSlim />
             <LeadCaptureForm />
             <Footer />
-
             <NoAIHypeFooter />
-          </div>
+          </SwipeLayout>
+        </div>
       </main>
     </SwipeNavigator>
   );


### PR DESCRIPTION
## Summary
- add a reusable SwipeLayout powered by react-swipeable for vertical navigation between landing sections
- scope the landing wallpaper to a dedicated hero background wrapper instead of the page shell
- clean up hero background CSS to avoid global fixed backgrounds while keeping existing overlays intact
- keep swipe sections from forcing full-screen height so existing layouts stay unchanged while swiping
- restore the hero mask tint with the original orange-to-blue gradient overlay layered above the wallpaper

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692d556cca58832db17519b6bdc6ac07)