### PR TITLE
Handle hero wallpaper fallback on iOS

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -32,6 +32,20 @@
   overflow: hidden;
 }
 
+.hero-background::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background-image: var(--hero-wallpaper-image);
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: center top;
+  background-attachment: fixed;
+  pointer-events: none;
+  z-index: -1;
+  transform: translateZ(0);
+}
+
 .hero-gradient-tint {
   position: absolute;
   inset: 0;
@@ -85,6 +99,13 @@
   .landing-shell,
   .dashboard-shell {
     background-attachment: scroll !important;
+  }
+
+  /* iOS: avoid fixed attachment jitter by using fixed positioning + scroll attachment */
+  .hero-background::before {
+    position: fixed;
+    background-attachment: scroll !important;
+    transform: translateZ(0);
   }
 }
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -43,13 +43,17 @@ const Index = () => {
     backgroundImage: `url(${backgroundImage})`,
   } as CSSProperties;
 
+  const wallpaperVariables = {
+    ["--hero-wallpaper-image" as const]: `url(${backgroundImage})`,
+  } as CSSProperties;
+
   const landingBackgroundStyle = {
     backgroundColor: "hsl(0, 0%, 97%)", // Fallback color if image fails (light gray)
   } as CSSProperties;
 
   return (
     <SwipeNavigator>
-      <div className="relative min-h-screen">
+      <div className="relative min-h-screen" style={wallpaperVariables}>
         <div
           id="app-home"
           className="fixed inset-0 -z-10 pointer-events-none bg-no-repeat bg-cover bg-center"


### PR DESCRIPTION
## Summary
- add a dedicated hero background pseudo-element that uses the shared wallpaper image variable
- override the iOS @supports rule to use scroll attachment with fixed positioning to avoid background jitter
- expose the wallpaper image as a CSS variable on the landing wrapper for the pseudo-element

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692d9b75a518832d93bd0b702c7d874f)