### PR TITLE
Fix: add main landmark to homepage container

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -61,7 +61,7 @@ const Index = () => {
       >
         <div className="fixed inset-0 z-0 pointer-events-none"></div>
         {/* Content with translucency - Optimized for performance */}
-        <div className="relative z-10" style={{ minHeight: "100vh" }}>
+        <div className="relative z-10" style={{ minHeight: "100vh" }} role="main">
           <AISEOHead
               title="TradeLine 24/7 - Your 24/7 AI Receptionist!"
               description="Get fast and reliable customer service that never sleeps. Handle calls, messages, and inquiries 24/7 with human-like responses. Start growing now!"


### PR DESCRIPTION
## Summary
- add an explicit `role="main"` to the homepage content wrapper to preserve main landmark semantics after replacing the `<main>` tag

## Testing
- npm run -s build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69317af5cb84832d853ac21d7d10ece5)