### PR TITLE
Remove redundant main role on homepage

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -55,7 +55,7 @@ const Index = () => {
       />
       <main className="landing-shell min-h-screen flex flex-col relative">
         {/* Content with translucency - Optimized for performance */}
-        <div className="relative z-10" style={{ minHeight: "100vh" }} role="main">
+        <div className="relative z-10" style={{ minHeight: "100vh" }}>
           <AISEOHead
               title="TradeLine 24/7 - Your 24/7 AI Receptionist!"
               description="Get fast and reliable customer service that never sleeps. Handle calls, messages, and inquiries 24/7 with human-like responses. Start growing now!"
@@ -142,7 +142,7 @@ const Index = () => {
             <NoAIHypeFooter />
           </div>
         </div>
-      </div>
+      </main>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- remove the redundant `role="main"` attribute from the homepage shell to rely on native semantics

## Testing
- npm test -- src/pages/__tests__/Index.spec.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69319f0db9e8832db58ca29e9c190efc)