### PR TITLE
Add footer trust badges and regression test

### DIFF
--- a/docs/devops-mastery-prep.md
+++ b/docs/devops-mastery-prep.md
@@ -1,0 +1,63 @@
+# DevOps Mastery Preparation Blueprint
+
+## Executive Snapshot
+- **Objective:** Equip the team for imminent high-rigor DevOps tasks with battle-tested habits, guardrails, and fast decision frameworks.
+- **Posture:** Bias for reliability over novelty, with repeatable workflows and auditable outcomes.
+
+## Core Assumptions & Stress Tests
+| Assumption | Hidden Risk / Counterpoint | Mitigation |
+| --- | --- | --- |
+| Automation always accelerates delivery. | Poorly scoped automation amplifies outages and MTTR if rollback paths are unclear. | Enforce pre-flight checklists, dry-runs, and reversible deployments (blue/green or canary by default). |
+| Observability is sufficient once metrics exist. | Metrics without SLOs/alerts create noise; alert fatigue masks real incidents. | Define SLOs per service, bind alerts to error budgets, and require runbooks with owner names. |
+| Security scanners in CI are enough. | Supply-chain and secret sprawl bypass scanners; ephemeral creds leak via logs. | Mandate SBOM diffing, secret scanning on commit, and scoped short-lived tokens with zero-log policies. |
+| Infra drift is negligible with IaC. | Manual hotfixes or console clicks cause skew and unpredictable rollbacks. | Nightly drift detection with auto-ticketing; terraform plan diffs must be approved before apply. |
+| Scaling policies cover peak loads. | Auto-scaling lags on cold starts; thundering herds exhaust shared dependencies. | Pre-warm critical paths, rate-limit at edges, and enforce circuit breakers with fallbacks. |
+
+## Adjacent Context to Maximize Readiness
+- **Dependency Health:** Track SBOM changes per build; block deploys on new critical CVEs without compensating controls.
+- **Release Mechanics:** Prefer canary + feature flags; every rollout must have a time-bounded rollback plan and data migration reversal notes.
+- **Data Safety:** Schema migrations run with idempotent guards; require shadow reads for destructive changes.
+- **Resilience:** Standardize circuit breaker thresholds and retry backoff policies across services; chaos drills monthly.
+- **Access Governance:** Just-in-time access with auto-expiry; audit trails routed to immutable storage with 90-day retention.
+
+## Action Modules (Modular, Reusable)
+1. **Pre-Deployment Gate**
+   - Inputs: ticket ID, risk rating, rollback steps, change owner.
+   - Checks: lint/typecheck, unit + targeted integration suites, secrets scan, SBOM delta review.
+   - Outcome: go/no-go with recorded approvals.
+
+2. **Progressive Delivery Playbook**
+   - Steps: 1% canary → 10% → 50% → 100% with error-budget-aware halt criteria.
+   - Observability: golden signals (latency, errors, saturation, traffic) plus domain KPIs per step.
+   - Rollback: automated revert button with config/state parity checks.
+
+3. **Incident-Ready Telemetry**
+   - Baseline dashboards: SLI/SLO views, deploy markers, and dependency health.
+   - Alerts: paging only on user-impacting SLO breaches; everything else to chat with ticket auto-creation.
+   - Runbooks: per-alert playbooks with last verification date and DRIs.
+
+4. **Post-Deploy Assurance**
+   - Tasks: synthetic checks, contract tests for upstream/downstream, error-rate diffing vs. baseline.
+   - Sign-off: record in change log with MTTR/MTBF impact assessment.
+
+5. **Drift & Compliance Watch**
+   - Daily terraform/helm drift reports; block applies when drift > defined threshold.
+   - Compliance hooks: data residency checks, PII flow inventory updates, and least-privilege audits.
+
+## Key Metrics to Track
+- **Stability:** Change failure rate, MTTR, rollback frequency, saturation of critical dependencies.
+- **Velocity with Safety:** Lead time for changes, time-to-restore after failed deploy, canary-to-full rollout duration.
+- **Quality:** Test flake rate, alert precision (pages leading to action), incident repeat rate.
+- **Security:** Secret exposure time-to-contain, SBOM delta approval latency, privileged session duration.
+
+## Non-Obvious Levers
+- **Error-Budget-Aware Feature Flags:** Auto-throttle new features when budgets are burning instead of blanket freeze.
+- **Adaptive Runbooks:** Store runbooks as parameterized templates that auto-populate with live metrics and recent deploy data.
+- **Shadow Migrations:** Mirror write paths to a dark database/schema to validate load and data quality before cutover.
+
+## Immediate Next Moves
+- Stand up a minimal pre-deploy gate (lint, unit, secrets scan) with recorded approvals.
+- Define top 3 SLOs per critical service and align alert policies to error budgets.
+- Implement canary scaffolding with rollback automation and deploy markers in dashboards.
+- Schedule a chaos drill focused on dependency saturation and circuit breaker efficacy.
+

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -4,27 +4,68 @@ import { usePWA } from '@/hooks/usePWA';
 import { Button } from '@/components/ui/button';
 import { Download } from 'lucide-react';
 
+const navLinks = [
+  { href: '/security', label: 'Security' },
+  { href: '/compare', label: 'Compare' },
+  { href: '/privacy', label: 'Privacy' },
+  { href: '/terms', label: 'Terms' },
+  { href: 'mailto:info@tradeline247ai.com', label: 'Contact' },
+];
+
+const trustBadges = [
+  {
+    title: 'Backed by Alberta Innovates',
+    alt: 'Alberta Innovates logo',
+    logo: '/alberta-innovates.svg',
+    abbreviation: 'AI',
+  },
+  {
+    title: 'Powered by OpenAI',
+    alt: 'OpenAI logo placeholder',
+    logo: null,
+    abbreviation: 'OA',
+  },
+  {
+    title: 'Payments by Stripe',
+    alt: 'Stripe logo placeholder',
+    logo: null,
+    abbreviation: 'S',
+  },
+  {
+    title: 'Infrastructure on Vercel',
+    alt: 'Vercel logo placeholder',
+    logo: null,
+    abbreviation: 'V',
+  },
+];
+
 export const Footer: React.FC = () => {
   const { isInstallable, isInstalled, showInstallPrompt } = usePWA();
 
   return (
     <footer className="border-t bg-background mt-auto" role="contentinfo">
-      <div className="container py-4">
-        <div className="flex flex-col md:flex-row justify-between items-center gap-4">
-          <div className="text-center md:text-left">
-            <div className="flex items-center gap-2 mb-2">
+      <div className="container py-8 md:py-10 space-y-8">
+        <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+          <div className="space-y-3 text-center md:text-left">
+            <div className="flex items-center justify-center md:justify-start gap-2">
               <Logo variant="text" size="sm" />
+              <span className="text-base font-semibold tracking-tight text-foreground">TradeLine 24/7</span>
             </div>
-            <address className="not-italic text-sm">
-              <strong>Apex Business Systems</strong> • Edmonton, Alberta • Built Canadian<br />
-              <a href="mailto:info@tradeline247ai.com" className="hover:text-foreground transition-colors" style={{ color: '#FF6B35' }}>info@tradeline247ai.com</a>
+            <address className="not-italic text-sm text-muted-foreground leading-relaxed">
+              <strong className="text-foreground">Apex Business Systems</strong> • Edmonton, Alberta • Built Canadian<br />
+              <a
+                href="mailto:info@tradeline247ai.com"
+                className="font-medium text-primary hover:text-primary/80 transition-colors"
+              >
+                info@tradeline247ai.com
+              </a>
             </address>
-            <div className="flex items-center gap-3 text-sm text-muted-foreground mt-2">
-              <span>© 2025 <span style={{ color: '#FF6B35' }}>TradeLine 24/7</span>. Never miss a call. We got it.</span>
-            </div>
+            <p className="text-sm text-muted-foreground">
+              © 2025 <span className="text-primary font-semibold">TradeLine 24/7</span>. Never miss a call. We got it.
+            </p>
           </div>
-          
-          <nav className="flex flex-wrap items-center justify-center gap-4 md:gap-6">
+
+          <nav className="flex flex-wrap items-center justify-center gap-3 md:gap-5 text-sm text-muted-foreground">
             {isInstallable && !isInstalled && (
               <Button
                 variant="outline"
@@ -37,37 +78,48 @@ export const Footer: React.FC = () => {
                 Install App
               </Button>
             )}
-            <a 
-              href="/security" 
-              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-            >
-              Security
-            </a>
-            <a 
-              href="/compare" 
-              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-            >
-              Compare
-            </a>
-            <a 
-              href="/privacy" 
-              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-            >
-              Privacy
-            </a>
-            <a 
-              href="/terms" 
-              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-            >
-              Terms
-            </a>
-            <a 
-              href="mailto:info@tradeline247ai.com" 
-              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-            >
-              Contact
-            </a>
+            {navLinks.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                className="transition-colors hover:text-foreground"
+              >
+                {link.label}
+              </a>
+            ))}
           </nav>
+        </div>
+
+        <div className="border-t border-border/70 pt-6">
+          <div className="flex flex-wrap items-center justify-center gap-3 md:gap-4">
+            {trustBadges.map((badge) => (
+              <div
+                key={badge.title}
+                className="flex items-center gap-3 rounded-lg border bg-muted/50 px-3 py-2 shadow-sm"
+                data-testid="trust-badge"
+              >
+                {badge.logo ? (
+                  <img
+                    src={badge.logo}
+                    alt={badge.alt}
+                    className="h-8 w-auto object-contain"
+                    loading="lazy"
+                  />
+                ) : (
+                  <div
+                    className="flex h-8 w-8 items-center justify-center rounded-md bg-muted text-xs font-semibold uppercase text-muted-foreground"
+                    aria-label={badge.alt}
+                  >
+                    {badge.abbreviation}
+                  </div>
+                )}
+                <div className="text-left">
+                  <div className="text-sm font-semibold leading-tight text-foreground">{badge.title}</div>
+                  <div className="text-xs text-muted-foreground">Ecosystem partner</div>
+                </div>
+              </div>
+            ))}
+          </div>
         </div>
       </div>
     </footer>

--- a/src/components/layout/__tests__/Footer.test.tsx
+++ b/src/components/layout/__tests__/Footer.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { Footer } from '../Footer';
+
+vi.mock('@/hooks/usePWA', () => ({
+  usePWA: () => ({ isInstallable: false, isInstalled: false, showInstallPrompt: vi.fn() }),
+}));
+
+describe('Footer', () => {
+  it('renders brand, nav links, and trust badges', () => {
+    render(<Footer />);
+
+    expect(screen.getByText(/TradeLine 24\/7/i)).toBeInTheDocument();
+    expect(screen.getByText(/Apex Business Systems/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /info@tradeline247ai.com/i })).toBeInTheDocument();
+
+    ['Security', 'Compare', 'Privacy', 'Terms', 'Contact'].forEach((label) => {
+      expect(screen.getByRole('link', { name: label })).toBeInTheDocument();
+    });
+
+    const badges = screen.getAllByTestId('trust-badge');
+    expect(badges.length).toBeGreaterThanOrEqual(4);
+    expect(screen.getByText(/Backed by Alberta Innovates/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- refresh the global footer layout with brand block, nav links, and new ecosystem trust badges
- add accessible trust badge placeholders/logos that avoid overlay behavior while matching the design system
- introduce a footer regression test to verify brand, navigation, and badge presence

## Testing
- `bun run test -- src/components/layout/__tests__/Footer.test.tsx` *(fails: environment missing node/npx executables required by test runner)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6932cfd5ccb0832daad12e12b7df9c3e)