### PR TITLE
Reuse server rate limit on follow-up checks

### DIFF
--- a/src/hooks/__tests__/useSecureFormSubmission.test.ts
+++ b/src/hooks/__tests__/useSecureFormSubmission.test.ts
@@ -4,7 +4,10 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
-import { useSecureFormSubmission } from '../useSecureFormSubmission';
+import {
+  RATE_LIMIT_ERROR_MESSAGE,
+  useSecureFormSubmission,
+} from '../useSecureFormSubmission';
 
 vi.mock('@/lib/errorReporter', () => ({
   errorReporter: {
@@ -159,6 +162,109 @@ describe('useSecureFormSubmission', () => {
       });
     });
 
+    it('should use server-provided limit when calculating attempts and remaining', async () => {
+      mockRpc.mockResolvedValue({
+        data: { allowed: true, remaining: 1, limit: 3 },
+        error: null,
+      });
+
+      const { result } = renderHook(() =>
+        useSecureFormSubmission({
+          rateLimitKey: 'test-key',
+          maxAttemptsPerHour: 10,
+        })
+      );
+
+      await act(async () => {
+        await result.current.checkRateLimit();
+      });
+
+      await waitFor(() => {
+        expect(result.current.attempts).toBe(2);
+        expect(result.current.getRemainingAttempts()).toBe(1);
+      });
+    });
+
+    it('should preserve the server limit when a subsequent rate limit check errors', async () => {
+      mockRpc
+        .mockResolvedValueOnce({
+          data: { allowed: true, remaining: 9, limit: 10 },
+          error: null,
+        })
+        .mockResolvedValueOnce({
+          data: null,
+          error: { message: 'Database error' },
+        });
+
+      const { result } = renderHook(() =>
+        useSecureFormSubmission({
+          rateLimitKey: 'test-key',
+          maxAttemptsPerHour: 5,
+        })
+      );
+
+      await act(async () => {
+        await result.current.checkRateLimit();
+      });
+
+      await waitFor(() => {
+        expect(result.current.attempts).toBe(1);
+      });
+
+      const allowed = await result.current.checkRateLimit();
+
+      expect(allowed).toBe(false);
+
+      await waitFor(() => {
+        expect(result.current.attempts).toBe(10);
+        expect(result.current.getRemainingAttempts()).toBe(0);
+      });
+    });
+
+    it('should reuse the last server-provided limit on subsequent checks', async () => {
+      mockRpc
+        .mockResolvedValueOnce({
+          data: { allowed: true, remaining: 8, limit: 10 },
+          error: null,
+        })
+        .mockResolvedValueOnce({
+          data: { allowed: true, remaining: 7, limit: 10 },
+          error: null,
+        });
+
+      const { result } = renderHook(() =>
+        useSecureFormSubmission({
+          rateLimitKey: 'test-key',
+          maxAttemptsPerHour: 5,
+        })
+      );
+
+      await act(async () => {
+        await result.current.checkRateLimit();
+      });
+
+      await waitFor(() => {
+        expect(result.current.attempts).toBe(2);
+        expect(result.current.getRemainingAttempts()).toBe(8);
+      });
+
+      await act(async () => {
+        await result.current.checkRateLimit();
+      });
+
+      expect(mockRpc).toHaveBeenNthCalledWith(1, 'secure_rate_limit', {
+        identifier: 'test-key',
+        max_requests: 5,
+        window_seconds: 3600,
+      });
+
+      expect(mockRpc).toHaveBeenNthCalledWith(2, 'secure_rate_limit', {
+        identifier: 'test-key',
+        max_requests: 10,
+        window_seconds: 3600,
+      });
+    });
+
     it('should deny when rate limit exceeded', async () => {
       mockRpc.mockResolvedValue({
         data: { allowed: false, remaining: 0, limit: 5 },
@@ -174,8 +280,13 @@ describe('useSecureFormSubmission', () => {
       await act(async () => {
         allowed = await result.current.checkRateLimit();
       });
-      
+
       expect(allowed).toBe(false);
+
+      await waitFor(() => {
+        expect(result.current.attempts).toBe(5);
+        expect(result.current.getRemainingAttempts()).toBe(0);
+      });
     });
 
     it('should deny on rate limit check error (fail closed)', async () => {
@@ -187,10 +298,14 @@ describe('useSecureFormSubmission', () => {
       const { result } = renderHook(() => useSecureFormSubmission({
         rateLimitKey: 'test-key',
       }));
-      
+
       const allowed = await result.current.checkRateLimit();
-      
+
       expect(allowed).toBe(false);
+
+      await waitFor(() => {
+        expect(result.current.attempts).toBe(5);
+      });
     });
 
     it('should deny on rate limit check exception (fail closed)', async () => {
@@ -205,8 +320,12 @@ describe('useSecureFormSubmission', () => {
       await act(async () => {
         allowed = await result.current.checkRateLimit();
       });
-      
+
       expect(allowed).toBe(false);
+
+      await waitFor(() => {
+        expect(result.current.attempts).toBe(5);
+      });
     });
   });
 
@@ -361,9 +480,11 @@ describe('useSecureFormSubmission', () => {
       await act(async () => {
         await expect(
           result.current.secureSubmit('test-endpoint', {})
-        ).rejects.toThrow('Rate limit exceeded');
+        ).rejects.toThrow(RATE_LIMIT_ERROR_MESSAGE);
       });
 
+      expect(result.current.attempts).toBe(5);
+      expect(result.current.getRemainingAttempts()).toBe(0);
       expect(mockInvoke).not.toHaveBeenCalled();
     });
 

--- a/src/hooks/useSecureFormSubmission.ts
+++ b/src/hooks/useSecureFormSubmission.ts
@@ -2,25 +2,30 @@ import { useState } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { errorReporter } from '@/lib/errorReporter';
 
+export const RATE_LIMIT_ERROR_MESSAGE = 'Rate limit exceeded. Please try again later.';
+
 interface SecureSubmissionOptions {
   rateLimitKey?: string;
   maxAttemptsPerHour?: number;
 }
 
 export const useSecureFormSubmission = (options: SecureSubmissionOptions = {}) => {
+  const { rateLimitKey, maxAttemptsPerHour = 5 } = options;
+
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [attempts, setAttempts] = useState(0);
-  
-  const { rateLimitKey, maxAttemptsPerHour = 5 } = options;
+  const [currentLimit, setCurrentLimit] = useState(maxAttemptsPerHour);
 
   const checkRateLimit = async (): Promise<boolean> => {
     if (!rateLimitKey) return true;
-    
+
+    const limitForRequest = currentLimit || maxAttemptsPerHour;
+
     try {
       // Use server-side rate limiting via RPC function
       const { data, error } = await supabase.rpc('secure_rate_limit', {
         identifier: rateLimitKey,
-        max_requests: maxAttemptsPerHour,
+        max_requests: limitForRequest,
         window_seconds: 3600
       });
 
@@ -34,14 +39,25 @@ export const useSecureFormSubmission = (options: SecureSubmissionOptions = {}) =
           environment: errorReporter['getEnvironment'](),
           metadata: { rateLimitKey, error }
         });
+        setAttempts(limitForRequest);
         // Fail closed - deny on error to prevent bypass
         return false;
       }
 
       // Parse the response - RPC returns Json type
       const result = data as { allowed: boolean; remaining: number; limit: number };
-      
+      const limit = result?.limit ?? limitForRequest;
+      const remaining = typeof result?.remaining === 'number' ? result.remaining : limit;
+
+      const normalizedRemaining = Math.max(0, Math.min(limit, remaining));
+
+      setCurrentLimit(limit);
+
       if (!result?.allowed) {
+        const attemptsUsed = limit - normalizedRemaining;
+
+        setAttempts(Math.min(limit, Math.max(0, attemptsUsed || limit)));
+
         errorReporter.report({
           type: 'error',
           message: `Rate limit exceeded for: ${rateLimitKey}`,
@@ -54,7 +70,7 @@ export const useSecureFormSubmission = (options: SecureSubmissionOptions = {}) =
         return false;
       }
 
-      setAttempts(maxAttemptsPerHour - (result.remaining || 0));
+      setAttempts(Math.min(limit, Math.max(0, limit - normalizedRemaining)));
       return true;
     } catch (error) {
       errorReporter.report({
@@ -67,6 +83,7 @@ export const useSecureFormSubmission = (options: SecureSubmissionOptions = {}) =
         environment: errorReporter['getEnvironment'](),
         metadata: { rateLimitKey, error }
       });
+      setAttempts(limitForRequest);
       // Fail closed - deny on error to prevent bypass
       return false;
     }
@@ -83,8 +100,8 @@ export const useSecureFormSubmission = (options: SecureSubmissionOptions = {}) =
   };
 
   const secureSubmit = async <T>(
-    endpoint: string, 
-    data: any, 
+    endpoint: string,
+    data: any,
     options: { 
       validateResponse?: (response: any) => boolean;
       sanitizeData?: (data: any) => any;
@@ -92,7 +109,8 @@ export const useSecureFormSubmission = (options: SecureSubmissionOptions = {}) =
   ): Promise<T> => {
     const rateLimitPassed = await checkRateLimit();
     if (!rateLimitPassed) {
-      throw new Error('Rate limit exceeded. Please try again later.');
+      // Surface a consistent error message for callers and tests
+      throw new Error(RATE_LIMIT_ERROR_MESSAGE);
     }
 
     setIsSubmitting(true);
@@ -132,7 +150,7 @@ export const useSecureFormSubmission = (options: SecureSubmissionOptions = {}) =
   };
 
   const getRemainingAttempts = (): number => {
-    return Math.max(0, maxAttemptsPerHour - attempts);
+    return Math.max(0, currentLimit - attempts);
   };
 
   return {


### PR DESCRIPTION
## Summary
- send rate-limit RPCs using the last server-provided limit to stay aligned with server-side configuration
- clamp remaining-attempts math to the active limit and add coverage for reusing server limits across checks

## Testing
- bun x vitest run src/hooks/__tests__/useSecureFormSubmission.test.ts *(fails: Vitest unhandled error `Cannot access 'dispose' before initialization` in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6933d75c4fc0832da52c0f6e231ab0b4)