### PR TITLE
Fix dashboard JSX and stabilize CTA smoke test

### DIFF
--- a/src/components/ui/ConnectionIndicator.tsx
+++ b/src/components/ui/ConnectionIndicator.tsx
@@ -102,18 +102,18 @@ function getStatusColor(quality: string): string {
  * Connection Indicator Component
  * Memoized to prevent unnecessary re-renders when network status hasn't changed
  */
-export const ConnectionIndicator: React.FC<ConnectionIndicatorProps> = React.memo(({
-  showOnlyWhenIssues = true,
-  position = 'bottom-right',
-  className,
-}) => {
-  const { status, queuedRequestCount } = useNetworkStatus();
-  const { user, isAdmin, userRole } = useAuth();
-  const [isVisible, setIsVisible] = useState(false);
-  const [announced, setAnnounced] = useState(false);
-  const { user, userRole, isAdmin: authIsAdmin } = useAuth();
+  export const ConnectionIndicator: React.FC<ConnectionIndicatorProps> = React.memo(({
+    showOnlyWhenIssues = true,
+    position = 'bottom-right',
+    className,
+  }) => {
+    const { status, queuedRequestCount } = useNetworkStatus();
+    const { user, isAdmin, userRole } = useAuth();
+    const authIsAdmin = isAdmin;
+    const [isVisible, setIsVisible] = useState(false);
+    const [announced, setAnnounced] = useState(false);
 
-  const isAdminUser = Boolean(user) && (typeof authIsAdmin === 'function' ? authIsAdmin() : userRole === 'admin');
+    const isAdminUser = Boolean(user) && (typeof authIsAdmin === 'function' ? authIsAdmin() : userRole === 'admin');
   const isSlowConnection = status.quality === 'slow';
 
   const isUserAdmin = user

--- a/src/pages/ClientDashboard.tsx
+++ b/src/pages/ClientDashboard.tsx
@@ -44,9 +44,9 @@ const ClientDashboard = () => {
             <AlertTriangle className="h-4 w-4 text-amber-800 dark:text-yellow-400" />
             <AlertDescription className="flex items-center justify-between">
               <span className="text-yellow-800 dark:text-yellow-300">{error}</span>
-              <Button 
+              <Button
                 onClick={refresh}
-                variant="outline" 
+                variant="outline"
                 size="sm"
                 className="ml-4 h-auto px-3 py-1 text-xs"
               >
@@ -56,6 +56,8 @@ const ClientDashboard = () => {
             </AlertDescription>
           </Alert>
         )}
+
+      </div>
 
         <div className="container mx-auto px-4 py-8">
           <div className="mb-8">

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -11,7 +11,6 @@ export const paths = {
   previewHealth: "/preview-health",
   login: "/login",
   auth: "/auth",
-  login: "/login",
   dashboard: "/dashboard",
   calls: "/calls",
   callCenterLegacy: "/call-center",

--- a/tests/cta-smoke.spec.ts
+++ b/tests/cta-smoke.spec.ts
@@ -27,8 +27,9 @@ const CTAS = [
 test.describe('CTA Smoke Tests', () => {
   for (const cta of CTAS) {
     test(`${cta.name} should navigate to ${cta.expectedUrl}`, async ({ page }) => {
-      await page.goto(`${BASE_URL}${cta.page}`);
-      await page.waitForLoadState('networkidle'); // Playwright page load state
+      await page.goto(`${BASE_URL}${cta.page}`, {
+        waitUntil: 'domcontentloaded',
+      });
 
       const button = page.locator(cta.selector).first();
       await expect(button).toBeVisible({ timeout: 5000 });


### PR DESCRIPTION
## Summary
- Fix ClientDashboard JSX structure so Vite/esbuild can compile the page
- Adjust CTA smoke test navigation waits to use `domcontentloaded` for stability
- Resolve build-time duplicate declarations in ConnectionIndicator and duplicate login path entry

## Testing
- npm run lint
- npm run test
- npm run build
- npx playwright test tests/cta-smoke.spec.ts --reporter=line *(fails locally because Playwright browsers are not installed in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69356ca4c6c4832db75b19e2068a72fd)