### PR TITLE
Ignore generated iOS marketing icon

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Build web assets
         run: npm run build
 
+      - name: Ensure iOS 1024 icon exists
+        run: node scripts/ensure-ios-1024-icon.mjs
+
       - name: Sync Capacitor iOS project
         run: npx cap sync ios
 

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -36,6 +36,9 @@ jobs:
           npm run verify:app || true
           npm run verify:icons || true
 
+      - name: Ensure iOS 1024 icon exists
+        run: node scripts/ensure-ios-1024-icon.mjs
+
       - name: Sync Capacitor iOS
         run: |
           set -euo pipefail

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,8 @@ ios/App/App/public/
 ios/App/App/capacitor.config.json
 ios/App/App/config.xml
 ios/capacitor-cordova-ios-plugins/
+# iOS marketing icon restored by CI guard script
+ios/App/App/Assets.xcassets/AppIcon.appiconset/icon-1024.png
 
 # Playwright test artifacts
 test-results/

--- a/ios/App/App/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/App/App/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -5,6 +5,12 @@
       "idiom" : "universal",
       "platform" : "ios",
       "size" : "1024x1024"
+    },
+    {
+      "filename" : "icon-1024.png",
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
     }
   ],
   "info" : {

--- a/scripts/ensure-ios-1024-icon.mjs
+++ b/scripts/ensure-ios-1024-icon.mjs
@@ -1,0 +1,24 @@
+import fs from "fs";
+import path from "path";
+
+const SRC = "public/assets/brand/App_Icons/ios/AppStore1024.png";
+const DST = "ios/App/App/Assets.xcassets/AppIcon.appiconset/icon-1024.png";
+
+function exists(p) {
+  try { fs.accessSync(p); return true; } catch { return false; }
+}
+
+const dstDir = path.dirname(DST);
+fs.mkdirSync(dstDir, { recursive: true });
+
+if (!exists(SRC)) {
+  console.error(`Missing source icon: ${SRC}`);
+  process.exit(1);
+}
+
+if (!exists(DST)) {
+  fs.copyFileSync(SRC, DST);
+  console.log(`Restored iOS 1024 icon -> ${DST}`);
+} else {
+  console.log(`iOS 1024 icon already present -> ${DST}`);
+}


### PR DESCRIPTION
## Summary
- ignore the AppIcon marketing binary in the asset catalog since CI restores it from the source asset
- remove the tracked icon copy so workflows rely on the ensure-ios-1024-icon script

## Testing
- node scripts/ensure-ios-1024-icon.mjs
- test -f ios/App/App/Assets.xcassets/AppIcon.appiconset/icon-1024.png
- npx cap sync ios *(fails: web assets ./dist missing in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69411e94413c832db9f913fb812a73bf)