### PR TITLE
chore: restore Android workflow auto-trigger configuration

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -291,9 +291,11 @@ workflows:
         track: internal
     triggering:
       events:
-        []  # Manual trigger only - use Android Studio for local builds to save costs
+        - push
       branch_patterns:
-        []  # No automatic builds
+        - pattern: main
+          include: true
+          source: true
 
   # ────────────────────────────────────────────────────────────────────────────
   # WEB TESTS


### PR DESCRIPTION
- Restore automatic triggering for Android builds on push to main
- Keep Android local build guide for reference
- Maintain cost-effective local build option while enabling CI/CD automation

## Changes

<!-- Brief description of what changed -->

## React Hooks Checklist (H310-8)

- [ ] All hooks are at top-level (no conditional/looped hooks)
- [ ] No component function calls (e.g., `Component()` → use `<Component/>`)
- [ ] No early returns before hooks complete
- [ ] ESLint passes with zero hook warnings

## Evidence

## Supabase Auth URL Configuration

- [ ] Site URL set to production domain in Supabase Auth settings
- [ ] Redirect URLs cover magic-link and password-reset flows (HTTPS, no stray trailing slashes)

- [ ] Evidence attached (links to `/ops/twilio-evidence` or test results)
- [ ] Synthetic-smoke passing ([latest run](https://github.com/apex-business-systems/tradeline247/actions/workflows/synthetic-smoke.yml))
- [ ] Twilio Debugger webhook targets `ops-twilio-debugger-intake` (HTTPS)
- [ ] No new secrets in repo (all secrets go to GitHub environments)
- [ ] Store disclosure unchanged or updated (if applicable)

## Testing

<!-- How was this tested? -->

## Deployment Notes

<!-- Any special deployment considerations? -->

---

**For Ops Incidents:** Include CallSid/MessageSid, endpoint, timestamp, and [Twilio Debugger](https://console.twilio.com/us1/monitor/debugger) link.

