### PR TITLE
fix(ios): use correct xcworkspace path for CocoaPods

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -140,9 +140,8 @@ workflows:
 
           set -eo pipefail
 
-          # Detect Xcode workspace or project
-          WORKSPACE="$(find ios -maxdepth 4 -name '*.xcworkspace' | head -n 1 || true)"
-          PROJECT="$(find ios -maxdepth 4 -name '*.xcodeproj' | head -n 1 || true)"
+          # Find workspace but EXCLUDE the one inside .xcodeproj
+          WORKSPACE="$(find ios -maxdepth 3 -name '*.xcworkspace' -not -path '*.xcodeproj/*' | head -n 1 || true)"
 
           if [[ -n "$WORKSPACE" ]]; then
             echo "Using workspace: $WORKSPACE"
@@ -151,18 +150,10 @@ workflows:
               --scheme "${XCODE_SCHEME:-App}" \
               --config Release \
               --archive-flags="-destination 'generic/platform=iOS'"
-          elif [[ -n "$PROJECT" ]]; then
-            echo "Using project: $PROJECT"
-            xcode-project build-ipa \
-              --project "$PROJECT" \
-              --scheme "${XCODE_SCHEME:-App}" \
-              --config Release \
-              --archive-flags="-destination 'generic/platform=iOS'"
           else
-            echo "ERROR: No Xcode workspace or project found under ios/"
-            echo "Directory listing:"
-            ls -R ios || true
-            exit 2
+            echo "ERROR: No Xcode workspace found"
+            find ios -name '*.xcworkspace'
+            exit 1
           fi
 
       - name: Ensure canonical IPA artifact path


### PR DESCRIPTION
The find command was picking up ios/App/App.xcodeproj/project.xcworkspace instead of ios/App/App.xcworkspace. The inner workspace doesn't include CocoaPods dependencies, causing 'no such module Capacitor' error.

Excluded workspaces inside .xcodeproj directories with -not -path flag.

## Changes

<!-- Brief description of what changed -->

## React Hooks Checklist (H310-8)

- [ ] All hooks are at top-level (no conditional/looped hooks)
- [ ] No component function calls (e.g., `Component()` → use `<Component/>`)
- [ ] No early returns before hooks complete
- [ ] ESLint passes with zero hook warnings

## Evidence

## Supabase Auth URL Configuration

- [ ] Site URL set to production domain in Supabase Auth settings
- [ ] Redirect URLs cover magic-link and password-reset flows (HTTPS, no stray trailing slashes)

- [ ] Evidence attached (links to `/ops/twilio-evidence` or test results)
- [ ] Synthetic-smoke passing ([latest run](https://github.com/apex-business-systems/tradeline247/actions/workflows/synthetic-smoke.yml))
- [ ] Twilio Debugger webhook targets `ops-twilio-debugger-intake` (HTTPS)
- [ ] No new secrets in repo (all secrets go to GitHub environments)
- [ ] Store disclosure unchanged or updated (if applicable)

## Testing

<!-- How was this tested? -->

## Deployment Notes

<!-- Any special deployment considerations? -->

---

**For Ops Incidents:** Include CallSid/MessageSid, endpoint, timestamp, and [Twilio Debugger](https://console.twilio.com/us1/monitor/debugger) link.

