### PR TITLE
ci: align Supabase/GitHub secrets names and harden migrate preflight

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
-      PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+      SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
     steps:
       - uses: actions/checkout@v6
       - uses: supabase/setup-cli@v1
@@ -26,8 +26,9 @@ jobs:
       - name: Fail fast on main push when secrets missing
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
-          if [ -z "$PROJECT_ID" ] || [ -z "$SUPABASE_ACCESS_TOKEN" ]; then
-            echo "Missing Supabase secrets: SUPABASE_ACCESS_TOKEN or SUPABASE_PROJECT_ID"
+          set -euo pipefail
+          if [ -z "${SUPABASE_ACCESS_TOKEN:-}" ] || [ -z "${SUPABASE_PROJECT_REF:-}" ] || [ -z "${SUPABASE_DB_PASSWORD:-}" ]; then
+            echo "Missing required Supabase secrets: SUPABASE_ACCESS_TOKEN / SUPABASE_PROJECT_REF / SUPABASE_DB_PASSWORD"
             exit 1
           fi
       - name: Run migrations
@@ -35,7 +36,7 @@ jobs:
           if [ -n "$SUPABASE_ACCESS_TOKEN" ]; then
             echo "Remote migrate: enabled"
             echo "🔗 Linking Supabase project..."
-            supabase link --project-ref "$PROJECT_ID"
+            supabase link --project-ref "$SUPABASE_PROJECT_REF"
             echo "🚀 Applying migrations to remote database..."
             supabase db push --debug
           else

--- a/.github/workflows/db-repair.yml
+++ b/.github/workflows/db-repair.yml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: supabase/setup-cli@v1
         with:
-          version: latest
+          version: 2.20.3
       - name: Analyze drift (read-only)
         env:
-          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
-        run: supabase db push --db-url "$SUPABASE_DB_URL" --dry-run --debug || true
+          SUPABASE_DB_URL_SECRET: ${{ secrets.SUPABASE_DB_URL_SECRET }}
+        run: supabase db push --db-url "$SUPABASE_DB_URL_SECRET" --dry-run --debug || true

--- a/.github/workflows/supabase-secrets-sync.yml
+++ b/.github/workflows/supabase-secrets-sync.yml
@@ -5,6 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: supabase/setup-cli@v1
+        with:
+          version: 2.20.3
       - run: supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }} --password ${{ secrets.SUPABASE_DB_PASSWORD }}
       - run: |
           supabase secrets set TWILIO_ACCOUNT_SID=${{ secrets.TWILIO_ACCOUNT_SID }} \


### PR DESCRIPTION
## Changes

<!-- Brief description of what changed -->

## React Hooks Checklist (H310-8)

- [ ] All hooks are at top-level (no conditional/looped hooks)
- [ ] No component function calls (e.g., `Component()` → use `<Component/>`)
- [ ] No early returns before hooks complete
- [ ] ESLint passes with zero hook warnings

## Evidence

## Supabase Auth URL Configuration

- [ ] Site URL set to production domain in Supabase Auth settings
- [ ] Redirect URLs cover magic-link and password-reset flows (HTTPS, no stray trailing slashes)

- [ ] Evidence attached (links to `/ops/twilio-evidence` or test results)
- [ ] Synthetic-smoke passing ([latest run](https://github.com/apex-business-systems/tradeline247/actions/workflows/synthetic-smoke.yml))
- [ ] Twilio Debugger webhook targets `ops-twilio-debugger-intake` (HTTPS)
- [ ] No new secrets in repo (all secrets go to GitHub environments)
- [ ] Store disclosure unchanged or updated (if applicable)

## Testing

<!-- How was this tested? -->

## Deployment Notes

<!-- Any special deployment considerations? -->

---

**For Ops Incidents:** Include CallSid/MessageSid, endpoint, timestamp, and [Twilio Debugger](https://console.twilio.com/us1/monitor/debugger) link.

