### PR TITLE
fix(ci): remove false-positive const reassignment check from lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,19 +77,6 @@ jobs:
             echo "✅ No fetchPriority casing issues detected"
           fi
 
-      # Guardrail: Prevent const reassignment in Supabase functions (CodeQL js/assignment-to-constant)
-      - name: Check Supabase functions for const reassignment
-        run: |
-          echo "🔍 Checking Supabase functions for const reassignment patterns..."
-          if find supabase/functions -name "*.ts" -exec grep -l "const.*=" {} \; | xargs grep -n "const \w\+.*;" | grep -A5 -B5 "const \w\+.*;" | grep -E "(^\w+\.yml|\.ts):.*\b(const \w+.*=.*)" | head -10; then
-            echo "❌ Found potential const reassignment patterns in Supabase functions:"
-            echo "   This would trigger CodeQL js/assignment-to-constant alerts"
-            echo "   Use non-mutable patterns like: const varRaw = parseInt(input); const var = isFinite(varRaw) ? varRaw : 0;"
-            exit 1
-          else
-            echo "✅ No const reassignment patterns detected in Supabase functions"
-          fi
-
       - run: npm run -s lint --if-present
       - name: Report status (ci/lint)
         if: always()


### PR DESCRIPTION
- Removed flawed grep step that flagged valid TypeScript const declarations
- Step was causing 'Broken pipe' errors and blocking CI pipeline
- Standard ESLint will handle code quality checks instead

## Changes

<!-- Brief description of what changed -->

## React Hooks Checklist (H310-8)

- [ ] All hooks are at top-level (no conditional/looped hooks)
- [ ] No component function calls (e.g., `Component()` → use `<Component/>`)
- [ ] No early returns before hooks complete
- [ ] ESLint passes with zero hook warnings

## Evidence

## Supabase Auth URL Configuration

- [ ] Site URL set to production domain in Supabase Auth settings
- [ ] Redirect URLs cover magic-link and password-reset flows (HTTPS, no stray trailing slashes)

- [ ] Evidence attached (links to `/ops/twilio-evidence` or test results)
- [ ] Synthetic-smoke passing ([latest run](https://github.com/apex-business-systems/tradeline247/actions/workflows/synthetic-smoke.yml))
- [ ] Twilio Debugger webhook targets `ops-twilio-debugger-intake` (HTTPS)
- [ ] No new secrets in repo (all secrets go to GitHub environments)
- [ ] Store disclosure unchanged or updated (if applicable)

## Testing

<!-- How was this tested? -->

## Deployment Notes

<!-- Any special deployment considerations? -->

---

**For Ops Incidents:** Include CallSid/MessageSid, endpoint, timestamp, and [Twilio Debugger](https://console.twilio.com/us1/monitor/debugger) link.

