### PR TITLE
fix(ci): stop PLIST unbound var; robust iOS build numbering

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -12,7 +12,8 @@ workflows:
         XCODE_SCHEME: App
         BUNDLE_ID: com.apex.tradeline
         EXPECTED_IOS_VERSION: "1.0.8"
-        APP_STORE_ID: $APP_STORE_ID
+        # Do not redefine APP_STORE_ID here. Codemagic does not interpolate $APP_STORE_ID in vars,
+        # and this turns into a literal string that breaks ASC build-number lookup.
       xcode: 16.4
       node: 20.19.0
       npm: 10
@@ -57,8 +58,9 @@ workflows:
           bash scripts/ci/ios_set_version_build.sh
 
           echo "✅ Info.plist updated:"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$PLIST"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$PLIST"
+          PLIST_PATH="ios/App/App/Info.plist"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$PLIST_PATH"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$PLIST_PATH"
 
       # THIS is what wires the provisioning profile into the Xcode project (Goodbuild #130 behavior)
       - name: Configure code signing (use profiles)


### PR DESCRIPTION
### Motivation
- Fix the Codemagic failure where Step 8 crashes with `PLIST: unbound variable` by avoiding undefined `$PLIST` references in the same step. 
- Prevent the `APP_STORE_ID` variable from being accidentally overridden with a literal in `codemagic.yaml`, which breaks App Store Connect lookups. 
- Make build-number resolution deterministic and fail-fast with clear logs so the workflow runs once and produces predictable artifacts.

### Description
- Remove the literal `APP_STORE_ID: $APP_STORE_ID` entry from `codemagic.yaml` and add a comment explaining it must come from the imported variable group. 
- Replace prints that referenced the undefined `$PLIST` in the `Set iOS version/build` step with a local `PLIST_PATH="ios/App/App/Info.plist"` and print using that path. 
- Replace `scripts/ci/ios_set_version_build.sh` with a hardened script that uses `set -euo pipefail`, validates `EXPECTED_IOS_VERSION` and `Info.plist` existence, attempts an ASC lookup only when numeric `APP_STORE_ID` is present, falls back to a millisecond-epoch build number if needed, writes `CFBundleShortVersionString` and `CFBundleVersion`, asserts the written values, and exports `BUILD_NUMBER` and `PLIST_PATH` to `$CM_ENV`. 

### Testing
- Ran `rg -n "APP_STORE_ID:" codemagic.yaml` to confirm the literal override was removed and it succeeded. 
- Ran `rg -n '\$PLIST' codemagic.yaml` to validate prints now reference `PLIST_PATH` and it succeeded. 
- Ran `bash -n scripts/ci/ios_set_version_build.sh` for a shell syntax check and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6952dec44f60832d9827d3bc04dfb922)