### PR TITLE
Fix Codemagic iOS build IPA verification failure

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -122,12 +122,20 @@ workflows:
           TMP="$(mktemp -d)"
           unzip -q "$IPA" -d "$TMP"
 
-          PLIST_IN_IPA="$(find "$TMP/Payload" -maxdepth 4 -name Info.plist | head -n 1)"
-          if [[ -z "$PLIST_IN_IPA" ]]; then
-            echo "❌ Could not find Info.plist in IPA"
-            find "$TMP/Payload" -maxdepth 3 -print || true
+          # Direct path to App's Info.plist (NOT nested storyboard plists)
+          PLIST_IN_IPA="$TMP/Payload/App.app/Info.plist"
+
+          if [[ ! -f "$PLIST_IN_IPA" ]]; then
+            echo "❌ Info.plist not found at: $PLIST_IN_IPA"
+            echo "📂 Contents of Payload:"
+            ls -la "$TMP/Payload/" || true
+            echo "📂 Contents of App.app:"
+            ls -la "$TMP/Payload/App.app/" || true
+            rm -rf "$TMP"
             exit 1
           fi
+
+          echo "✅ IPA Info.plist: $PLIST_IN_IPA"
 
           V=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$PLIST_IN_IPA")
           B=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$PLIST_IN_IPA")


### PR DESCRIPTION
- Replace find command with direct path to App.app/Info.plist
- find was grabbing nested storyboard plist instead of app plist
- Add error handling with debug output if plist not found
- Fixes Step 11 'Verify IPA version + build' failure

## Changes

<!-- Brief description of what changed -->

## React Hooks Checklist (H310-8)

- [ ] All hooks are at top-level (no conditional/looped hooks)
- [ ] No component function calls (e.g., `Component()` → use `<Component/>`)
- [ ] No early returns before hooks complete
- [ ] ESLint passes with zero hook warnings

## Evidence

## Supabase Auth URL Configuration

- [ ] Site URL set to production domain in Supabase Auth settings
- [ ] Redirect URLs cover magic-link and password-reset flows (HTTPS, no stray trailing slashes)

- [ ] Evidence attached (links to `/ops/twilio-evidence` or test results)
- [ ] Synthetic-smoke passing ([latest run](https://github.com/apex-business-systems/tradeline247/actions/workflows/synthetic-smoke.yml))
- [ ] Twilio Debugger webhook targets `ops-twilio-debugger-intake` (HTTPS)
- [ ] No new secrets in repo (all secrets go to GitHub environments)
- [ ] Store disclosure unchanged or updated (if applicable)

## Testing

<!-- How was this tested? -->

## Deployment Notes

<!-- Any special deployment considerations? -->

---

**For Ops Incidents:** Include CallSid/MessageSid, endpoint, timestamp, and [Twilio Debugger](https://console.twilio.com/us1/monitor/debugger) link.

