### PR TITLE
Wire Twilio voice to frontdoor and add regression test

### DIFF
--- a/src/pages/ops/TwilioWire.tsx
+++ b/src/pages/ops/TwilioWire.tsx
@@ -21,8 +21,8 @@ export default function TwilioWire() {
   const productionUrl = 'https://hysvqdwmhxnblxfqnszn.supabase.co';
 
   const getWebhookUrls = (env: 'staging' | 'production') => ({
-    voice_answer: `${env === 'staging' ? stagingUrl : productionUrl}/functions/v1/voice-answer`,
-    voice_status: `${env === 'staging' ? stagingUrl : productionUrl}/functions/v1/voice-status`,
+    voice_frontdoor: `${env === 'staging' ? stagingUrl : productionUrl}/functions/v1/voice-frontdoor`,
+    voice_status: `${env === 'staging' ? stagingUrl : productionUrl}/functions/v1/voice-action`,
     sms_inbound: `${env === 'staging' ? stagingUrl : productionUrl}/functions/v1/sms-inbound`,
   });
 
@@ -64,7 +64,7 @@ export default function TwilioWire() {
       const { error } = await supabase.functions.invoke('ops-twilio-configure-webhooks', {
         body: {
           phoneNumber: selectedNumber,
-          voiceUrl: WEBHOOK_URLS.voice_answer,
+          voiceUrl: WEBHOOK_URLS.voice_frontdoor,
           voiceStatusCallback: WEBHOOK_URLS.voice_status,
           smsUrl: WEBHOOK_URLS.sms_inbound
         }
@@ -92,7 +92,7 @@ export default function TwilioWire() {
   const testWebhook = async (type: 'voice' | 'sms') => {
     setTesting(true);
     try {
-      const url = type === 'voice' ? WEBHOOK_URLS.voice_answer : WEBHOOK_URLS.sms_inbound;
+      const url = type === 'voice' ? WEBHOOK_URLS.voice_frontdoor : WEBHOOK_URLS.sms_inbound;
       
       const { error } = await supabase.functions.invoke('ops-twilio-test-webhook', {
         body: { url, type }

--- a/src/pages/ops/__tests__/TwilioWire.test.tsx
+++ b/src/pages/ops/__tests__/TwilioWire.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, vi, expect } from 'vitest';
+import TwilioWire from '../TwilioWire';
+
+vi.mock('@/integrations/supabase/client.ts', () => ({
+  supabase: {
+    functions: {
+      invoke: vi.fn().mockResolvedValue({ data: { numbers: [] }, error: null }),
+    },
+  },
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+describe('TwilioWire', () => {
+  it('renders voice frontdoor webhook for Twilio wiring', async () => {
+    render(<TwilioWire />);
+    expect(
+      await screen.findByText(/functions\/v1\/voice-frontdoor/i)
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Changes

<!-- Brief description of what changed -->

## React Hooks Checklist (H310-8)

- [ ] All hooks are at top-level (no conditional/looped hooks)
- [ ] No component function calls (e.g., `Component()` → use `<Component/>`)
- [ ] No early returns before hooks complete
- [ ] ESLint passes with zero hook warnings

## Evidence

## Supabase Auth URL Configuration

- [ ] Site URL set to production domain in Supabase Auth settings
- [ ] Redirect URLs cover magic-link and password-reset flows (HTTPS, no stray trailing slashes)

- [ ] Evidence attached (links to `/ops/twilio-evidence` or test results)
- [ ] Synthetic-smoke passing ([latest run](https://github.com/apex-business-systems/tradeline247/actions/workflows/synthetic-smoke.yml))
- [ ] Twilio Debugger webhook targets `ops-twilio-debugger-intake` (HTTPS)
- [ ] No new secrets in repo (all secrets go to GitHub environments)
- [ ] Store disclosure unchanged or updated (if applicable)

## Testing

<!-- How was this tested? -->

## Deployment Notes

<!-- Any special deployment considerations? -->

---

**For Ops Incidents:** Include CallSid/MessageSid, endpoint, timestamp, and [Twilio Debugger](https://console.twilio.com/us1/monitor/debugger) link.

