### PR TITLE
Integrate HeaderErrorBoundary with centralized error reporter

### DIFF
--- a/src/components/layout/HeaderErrorBoundary.tsx
+++ b/src/components/layout/HeaderErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
 import { Button } from '@/components/ui/button';
+import { reportReactError } from '@/lib/errorReporter';
 
 interface Props {
   children: ReactNode;
@@ -28,10 +29,8 @@ export class HeaderErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.error('[HeaderErrorBoundary] Component stack:', errorInfo.componentStack);
-    // Log to error tracking service in production
-    if (import.meta.env.PROD) {
-      // TODO: Send to error tracking service (Sentry, etc.)
-    }
+    // Report to centralized error handler (handles dev/prod logging and backend reporting)
+    reportReactError(error, errorInfo);
   }
 
   render() {

--- a/src/components/layout/__tests__/HeaderErrorBoundary.test.tsx
+++ b/src/components/layout/__tests__/HeaderErrorBoundary.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { HeaderErrorBoundary } from '../HeaderErrorBoundary';
+import { reportReactError } from '@/lib/errorReporter';
+
+// Mock error reporter
+vi.mock('@/lib/errorReporter', () => ({
+  reportReactError: vi.fn(),
+}));
+
+// Mock Button component
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, onClick, ...props }: any) => (
+    <button onClick={onClick} {...props}>{children}</button>
+  ),
+}));
+
+describe('HeaderErrorBoundary', () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Suppress console.error in tests to avoid noisy output for expected errors
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Mock window.location
+    delete (window as any).location;
+    (window as any).location = { href: '' };
+  });
+
+  afterEach(() => {
+    window.location = originalLocation;
+    vi.restoreAllMocks();
+  });
+
+  it('should render children when no error occurs', () => {
+    render(
+      <HeaderErrorBoundary>
+        <div data-testid="child-content">Child Content</div>
+      </HeaderErrorBoundary>
+    );
+
+    expect(screen.getByTestId('child-content')).toBeInTheDocument();
+    expect(screen.queryByTestId('header-error-fallback')).not.toBeInTheDocument();
+  });
+
+  it('should render fallback UI and report error when child throws', () => {
+    const ThrowError = () => {
+      throw new Error('Test error');
+    };
+
+    render(
+      <HeaderErrorBoundary>
+        <ThrowError />
+      </HeaderErrorBoundary>
+    );
+
+    // Verify fallback UI
+    expect(screen.getByTestId('header-error-fallback')).toBeInTheDocument();
+    expect(screen.getByText('Home')).toBeInTheDocument();
+    expect(screen.getByAltText('Built in Canada')).toBeInTheDocument();
+
+    // Verify error reporting
+    expect(reportReactError).toHaveBeenCalled();
+    expect(reportReactError).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ componentStack: expect.any(String) }));
+  });
+
+  it('should handle home button click in fallback UI', () => {
+    const ThrowError = () => {
+      throw new Error('Test error');
+    };
+
+    render(
+      <HeaderErrorBoundary>
+        <ThrowError />
+      </HeaderErrorBoundary>
+    );
+
+    const homeButton = screen.getByText('Home');
+    fireEvent.click(homeButton);
+
+    expect(window.location.href).toBe('/');
+  });
+
+  it('should handle login button click in fallback UI', () => {
+    const ThrowError = () => {
+      throw new Error('Test error');
+    };
+
+    render(
+      <HeaderErrorBoundary>
+        <ThrowError />
+      </HeaderErrorBoundary>
+    );
+
+    const loginButton = screen.getByText('Login');
+    fireEvent.click(loginButton);
+
+    expect(window.location.href).toBe('/auth');
+  });
+});


### PR DESCRIPTION
- Updated `HeaderErrorBoundary.tsx` to use `reportReactError` for centralized error reporting.
- Removed TODO comments.
- Added `HeaderErrorBoundary.test.tsx` to verify error reporting and fallback UI rendering.

---
*PR created automatically by Jules for task [15195812035943362075](https://jules.google.com/task/15195812035943362075) started by @apexbusiness-systems*