### PR TITLE
Implement rollback actions in telephony transaction

### DIFF
--- a/supabase/functions/_shared/__tests__/telephonyTransaction.test.ts
+++ b/supabase/functions/_shared/__tests__/telephonyTransaction.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TelephonyTransaction, RollbackAction } from '../telephonyTransaction.ts';
+import * as twilio from '../twilio.ts';
+
+// Mock Supabase Client
+const mockRpc = vi.fn();
+const mockFrom = vi.fn();
+const mockDelete = vi.fn();
+const mockUpdate = vi.fn();
+const mockEq = vi.fn();
+
+const mockSupabase = {
+  rpc: mockRpc,
+  from: mockFrom
+} as any;
+
+// Mock Twilio functions
+vi.mock('../twilio.ts', () => ({
+  releaseNumber: vi.fn(),
+  closeSubaccount: vi.fn(),
+  TwilioAuth: {},
+}));
+
+describe('TelephonyTransaction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockFrom.mockReturnValue({
+      delete: mockDelete,
+      update: mockUpdate
+    });
+    mockDelete.mockReturnValue({ eq: mockEq });
+    mockUpdate.mockReturnValue({ eq: mockEq });
+    mockEq.mockResolvedValue({ error: null });
+  });
+
+  it('should process release_number rollback action', async () => {
+    const tx = new TelephonyTransaction(mockSupabase, 'test_tx', 'org_123');
+    const action: RollbackAction = {
+      type: 'release_number',
+      payload: {
+        subSid: 'sub_123',
+        phoneNumberSid: 'pn_123',
+        accountSid: 'acc_123',
+        authToken: 'auth_123'
+      }
+    };
+
+    await tx.processRollbackAction(action);
+
+    expect(twilio.releaseNumber).toHaveBeenCalledWith(
+      expect.objectContaining({ accountSid: 'acc_123', authToken: 'auth_123' }),
+      'sub_123',
+      'pn_123'
+    );
+  });
+
+  it('should process close_subaccount rollback action', async () => {
+    const tx = new TelephonyTransaction(mockSupabase, 'test_tx', 'org_123');
+    const action: RollbackAction = {
+      type: 'close_subaccount',
+      payload: {
+        subSid: 'sub_123',
+        accountSid: 'acc_123',
+        authToken: 'auth_123'
+      }
+    };
+
+    await tx.processRollbackAction(action);
+
+    expect(twilio.closeSubaccount).toHaveBeenCalledWith(
+      expect.objectContaining({ accountSid: 'acc_123', authToken: 'auth_123' }),
+      'sub_123'
+    );
+  });
+
+  it('should process delete_supabase_row rollback action', async () => {
+    const tx = new TelephonyTransaction(mockSupabase, 'test_tx', 'org_123');
+    const action: RollbackAction = {
+      type: 'delete_supabase_row',
+      payload: {
+        table: 'some_table',
+        filter: { column: 'id', value: 'row_123' }
+      }
+    };
+
+    await tx.processRollbackAction(action);
+
+    expect(mockFrom).toHaveBeenCalledWith('some_table');
+    expect(mockDelete).toHaveBeenCalled();
+    expect(mockEq).toHaveBeenCalledWith('id', 'row_123');
+  });
+
+  it('should execute rollback actions on failure', async () => {
+    // Setup generic execute flow
+    const operation = vi.fn().mockRejectedValue(new Error('Operation failed'));
+
+    // Mock start
+    mockRpc.mockResolvedValueOnce({ data: 'tx_123', error: null }); // start
+    // Mock fail (called after operation fails)
+    mockRpc.mockResolvedValueOnce({ data: null, error: null }); // fail
+    // Mock rollback
+    const rollbackActions: RollbackAction[] = [
+      { type: 'delete_supabase_row', payload: { table: 't', filter: { column: 'c', value: 'v' } } }
+    ];
+    mockRpc.mockResolvedValueOnce({ data: rollbackActions, error: null }); // rollback
+
+    try {
+      await TelephonyTransaction.execute(
+        mockSupabase,
+        'test_tx',
+        'org_123',
+        operation
+      );
+    } catch (e: any) {
+      expect(e.message).toBe('Operation failed');
+    }
+
+    expect(mockRpc).toHaveBeenCalledWith('rollback_telephony_transaction', { p_tx_id: 'tx_123' });
+    // Verify processRollbackAction was called (implicitly via side effects)
+    expect(mockFrom).toHaveBeenCalledWith('t');
+    expect(mockEq).toHaveBeenCalledWith('c', 'v');
+  });
+});

--- a/supabase/functions/_shared/twilio.ts
+++ b/supabase/functions/_shared/twilio.ts
@@ -22,9 +22,10 @@ type TwilioPostOptions = {
   headers?: Record<string, string>;
 };
 
-export async function twilioFormPOST(
+export async function twilioRequest(
+  method: string,
   path: string,
-  form: URLSearchParams,
+  body: URLSearchParams | null,
   maxRetries = 4,
   opts: TwilioPostOptions = {},
 ) {
@@ -35,14 +36,19 @@ export async function twilioFormPOST(
   }
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const headers: Record<string, string> = {
+      Authorization: authHeader,
+      ...opts.headers,
+    };
+
+    if (body) {
+      headers["Content-Type"] = "application/x-www-form-urlencoded";
+    }
+
     const res = await fetch(`${TWILIO_API_BASE}${path}`, {
-      method: "POST",
-      headers: {
-        Authorization: authHeader,
-        "Content-Type": "application/x-www-form-urlencoded",
-        ...opts.headers,
-      },
-      body: form,
+      method,
+      headers,
+      body,
     });
 
     if (res.status === 429 || res.status >= 500) {
@@ -57,7 +63,16 @@ export async function twilioFormPOST(
     return res;
   }
 
-  throw new Error("twilioFormPOST exhausted retries");
+  throw new Error("twilioRequest exhausted retries");
+}
+
+export async function twilioFormPOST(
+  path: string,
+  form: URLSearchParams,
+  maxRetries = 4,
+  opts: TwilioPostOptions = {},
+) {
+  return await twilioRequest("POST", path, form, maxRetries, opts);
 }
 
 export const okHeaders = { ...corsHeaders, ...secureHeaders, "Content-Type": "application/json" };
@@ -112,5 +127,27 @@ export async function buyNumberAndBindWebhooks(
   });
   const res = await twilioFormPOST(`/Accounts/${subSid}/IncomingPhoneNumbers.json`, body, 4, { auth });
   if (!res.ok) throw new Error(`Buy/bind number failed: ${res.status}`);
+  return await res.json();
+}
+
+export async function releaseNumber(
+  auth: TwilioAuth,
+  subSid: string,
+  phoneNumberSid: string,
+) {
+  const res = await twilioRequest("DELETE", `/Accounts/${subSid}/IncomingPhoneNumbers/${phoneNumberSid}.json`, null, 4, { auth });
+  if (!res.ok && res.status !== 404) {
+    throw new Error(`Release number failed: ${res.status}`);
+  }
+  return res.status === 204 || res.status === 404; // Success if deleted or not found
+}
+
+export async function closeSubaccount(
+  auth: TwilioAuth,
+  subSid: string,
+) {
+  const body = new URLSearchParams({ Status: "suspended" });
+  const res = await twilioFormPOST(`/Accounts/${subSid}.json`, body, 4, { auth });
+  if (!res.ok) throw new Error(`Close subaccount failed: ${res.status}`);
   return await res.json();
 }


### PR DESCRIPTION
Implemented rollback logic for telephony transactions to clean up resources (Twilio numbers, subaccounts, Supabase rows) in case of failure. Refactored Twilio client to support generic requests. Added comprehensive unit tests.

---
*PR created automatically by Jules for task [8325543379425981936](https://jules.google.com/task/8325543379425981936) started by @apexbusiness-systems*