### PR TITLE
Replace RAG answer stub with OpenAI LLM call

### DIFF
--- a/supabase/functions/rag-answer/index.ts
+++ b/supabase/functions/rag-answer/index.ts
@@ -6,7 +6,12 @@
  */
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { OpenAI } from 'https://esm.sh/openai@4.28.0';
 import { corsHeaders, preflight } from '../_shared/cors.ts';
+
+const DEFAULT_MODEL = 'gpt-4o-mini';
+const DEFAULT_TEMPERATURE = 0.3; // Lower = more deterministic for RAG
+const DEFAULT_MAX_TOKENS = 500; // Reasonable for concise answers
 
 type AnyRecord = Record<string, unknown>;
 
@@ -93,8 +98,54 @@ async function checkRateLimit(
   }
 }
 
-function synthesizeAnswer(question: string, context: RagContextItem[], lang?: string): { answer: string; citations: { id?: string; snippet: string }[] } {
-  // TODO: Replace this stub with your actual LLM call (e.g., OpenAI, Vertex, Lovable AI)
+function buildSystemPrompt(lang?: string): string {
+  const basePrompt = `You are TradeLine 24/7's AI assistant, an expert in automotive trading, dealer operations, and business intelligence.
+
+CRITICAL INSTRUCTIONS:
+1. Answer ONLY using information from the provided context
+2. If the context doesn't contain relevant information, say: "I don't have enough information in my knowledge base to answer that question accurately."
+3. Never make up information or use knowledge outside the context
+4. Be concise and professional - this is a business application
+5. Cite specific parts of the context when possible
+6. Focus on actionable insights for automotive dealers
+
+FORMAT:
+- Keep answers under 200 words unless complexity requires more
+- Use bullet points for lists
+- Include relevant metrics or numbers from the context
+- Maintain professional automotive industry terminology`;
+
+  // Language-specific instruction
+  if (lang && !lang.toLowerCase().startsWith('en')) {
+    return `${basePrompt}\n\n7. RESPOND IN ${lang.toUpperCase()} LANGUAGE.`;
+  }
+
+  return basePrompt;
+}
+
+function buildUserPrompt(question: string, context: RagContextItem[]): string {
+  // Format context with clear separation
+  const contextStr = context
+    .map((item, idx) =>
+      `[Context ${idx + 1}${item.id ? ` - ID: ${item.id}` : ''}]
+${item.text}
+---`
+    )
+    .join('\n\n');
+
+  return `CONTEXT:
+${contextStr}
+
+QUESTION: ${question}
+
+ANSWER:`;
+}
+
+function synthesizeAnswerStub(
+  question: string,
+  context: RagContextItem[],
+  lang?: string
+): { answer: string; citations: { id?: string; snippet: string }[] } {
   const topSnippets = context
     .slice(0, 3)
     .map((c) => (c?.text ?? "").trim())
@@ -122,6 +173,59 @@ function synthesizeAnswer(question: string, context: RagContextItem[], lang?: st
     answer: `${langPrefix}${baseAnswer}`,
     citations,
   };
+}
+
+async function synthesizeAnswer(
+  question: string,
+  context: RagContextItem[],
+  model?: string,
+  temperature?: number,
+  maxTokens?: number,
+  lang?: string
+): Promise<{ answer: string; citations: { id?: string; snippet: string }[] }> {
+
+  const OPENAI_API_KEY = Deno.env.get('OPENAI_API_KEY');
+
+  // Graceful degradation if no API key
+  if (!OPENAI_API_KEY) {
+    console.warn('OPENAI_API_KEY not configured - using stub response');
+    return synthesizeAnswerStub(question, context, lang);
+  }
+
+  try {
+    const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
+
+    const systemPrompt = buildSystemPrompt(lang);
+    const userPrompt = buildUserPrompt(question, context);
+
+    const completion = await openai.chat.completions.create({
+      model: model || DEFAULT_MODEL,
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userPrompt }
+      ],
+      temperature: temperature ?? DEFAULT_TEMPERATURE,
+      max_tokens: maxTokens || DEFAULT_MAX_TOKENS,
+    });
+
+    const answer = completion.choices[0]?.message?.content ||
+                   'Unable to generate answer from context.';
+
+    // Extract citations from context (simple approach)
+    const citations = context.slice(0, 5).map(c => ({
+      id: c.id,
+      snippet: (c.text || '').slice(0, 150) + (c.text?.length > 150 ? '...' : '')
+    }));
+
+    return { answer, citations };
+
+  } catch (error) {
+    console.error('OpenAI API error:', error);
+
+    // Fail gracefully to stub on API errors
+    console.warn('Falling back to stub due to OpenAI error');
+    return synthesizeAnswerStub(question, context, lang);
+  }
 }
 
 async function handleRagAnswer(req: Request): Promise<Response> {
@@ -194,6 +298,8 @@ async function handleRagAnswer(req: Request): Promise<Response> {
     const filters = normalizeRecord(body.filters);
     const lang = typeof body.lang === "string" ? body.lang.trim() : undefined;
     const model = typeof body.model === "string" ? body.model.trim() : undefined;
+    const temperature = typeof body.temperature === "number" ? body.temperature : undefined;
+    const maxTokens = typeof body.maxTokens === "number" ? body.maxTokens : undefined;
 
     if (!question) {
       return new Response(
@@ -218,7 +324,14 @@ async function handleRagAnswer(req: Request): Promise<Response> {
       }
     }
 
-    const { answer, citations } = synthesizeAnswer(question, context, effectiveLang);
+    const { answer, citations } = await synthesizeAnswer(
+      question,
+      context,
+      model,
+      temperature,
+      maxTokens,
+      effectiveLang
+    );
 
     const payload: RagAnswerResponse = {
       ok: true,


### PR DESCRIPTION
Replaced the `synthesizeAnswer` stub in `supabase/functions/rag-answer/index.ts` with a production-ready implementation using the OpenAI API.

Key changes:
- Imported `OpenAI` client from `esm.sh`.
- Created `synthesizeAnswer` async function that calls OpenAI.
- Implemented `buildSystemPrompt` and `buildUserPrompt` with specific instructions for automotive context and anti-hallucination.
- Added fallback mechanism: if `OPENAI_API_KEY` is missing or the API call fails, it falls back to the original stub logic (`synthesizeAnswerStub`).
- Updated `handleRagAnswer` to await the new function and pass optional parameters (`model`, `temperature`, `maxTokens`).
- defaults to `gpt-4o-mini` model.

---
*PR created automatically by Jules for task [903114590307560728](https://jules.google.com/task/903114590307560728) started by @apexbusiness-systems*