### PR TITLE
Potential fix for code scanning alert no. 1164: Missing regular expression anchor

### DIFF
--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -20,7 +20,7 @@ export const initSentry = () => {
     tracePropagationTargets: [
       "localhost",
       /^https:\/\/.*\.supabase\.co/, // Matches Supabase projects
-      /^https:\/\/.*\.tradeline247ai\.com/ // Matches production domain
+      /^https:\/\/.*\.tradeline247ai\.com(\/|$)/ // Matches production domain
     ],
     // Session Replay
     replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.


### PR DESCRIPTION
Potential fix for [https://github.com/apexbusiness-systems/TradeLine247/security/code-scanning/1164](https://github.com/apexbusiness-systems/TradeLine247/security/code-scanning/1164)

In general, to fix this type of issue you ensure that the regular expression is anchored so that it matches only the intended hostname (optionally with any path), rather than allowing arbitrary suffixes. For host-based URL checks, that typically means adding either a `/` (to mark the end of the host portion and start of the path) or a `$` (to mark the end of the string) directly after the hostname in the pattern.

For this specific case in `src/lib/sentry.ts`, the safest fix that preserves current behavior (matching any path on the production domain) is to require that the string, after matching `https://<subdomain>.tradeline247ai.com`, either ends or continues with a `/`. This still allows all paths on that host while preventing matches like `https://api.tradeline247ai.com.evil.com/...`. The best concrete change is to update the regex on line 23 from:

```ts
/^https:\/\/.*\.tradeline247ai\.com/
```

to:

```ts
/^https:\/\/.*\.tradeline247ai\.com(\/|$)/
```

No new methods or imports are required; this is a simple regex literal adjustment within the `tracePropagationTargets` array.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
