### PR TITLE
Refactor admin role check into reusable middleware

### DIFF
--- a/server/middleware/__tests__/adminCheck.test.ts
+++ b/server/middleware/__tests__/adminCheck.test.ts
@@ -1,0 +1,134 @@
+import { Request, Response } from 'express';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+// Mock needs to be defined before imports that use it if not hoisted correctly,
+// but vi.mock is hoisted. We use a factory to prevent original module execution.
+vi.mock('../../supabase/client', () => ({
+  supabase: {
+    from: vi.fn(),
+    auth: {
+      getUser: vi.fn(),
+    },
+  },
+}));
+
+// Now import the module under test
+import { requireAdmin, checkAdminRole } from '../adminCheck';
+import { supabase } from '../../supabase/client';
+
+describe('requireAdmin middleware', () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let nextFunction: any;
+
+  beforeEach(() => {
+    mockRequest = {
+      // @ts-ignore
+      auth: {
+        userId: 'test-user-id',
+        supabaseClient: supabase,
+      },
+    };
+    mockResponse = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    };
+    nextFunction = vi.fn();
+  });
+
+  it('should call next() when user is admin', async () => {
+    (supabase.from as any).mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: { role: 'admin' },
+            error: null,
+          }),
+        }),
+      }),
+    });
+
+    await requireAdmin(
+      mockRequest as Request,
+      mockResponse as Response,
+      nextFunction
+    );
+
+    expect(nextFunction).toHaveBeenCalled();
+    expect(mockResponse.status).not.toHaveBeenCalled();
+  });
+
+  it('should return 403 when user is not admin', async () => {
+    (supabase.from as any).mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: { role: 'user' },
+            error: null,
+          }),
+        }),
+      }),
+    });
+
+    await requireAdmin(
+      mockRequest as Request,
+      mockResponse as Response,
+      nextFunction
+    );
+
+    expect(mockResponse.status).toHaveBeenCalledWith(403);
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      success: false,
+      error: 'Forbidden - Admin role required',
+    });
+    expect(nextFunction).not.toHaveBeenCalled();
+  });
+
+  it('should return 401 when auth is missing', async () => {
+    // @ts-ignore
+    mockRequest.auth = undefined;
+
+    await requireAdmin(
+      mockRequest as Request,
+      mockResponse as Response,
+      nextFunction
+    );
+
+    expect(mockResponse.status).toHaveBeenCalledWith(401);
+    expect(nextFunction).not.toHaveBeenCalled();
+  });
+
+  describe('checkAdminRole helper', () => {
+    it('should return true when user is admin', async () => {
+      (supabase.from as any).mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { role: 'admin' },
+              error: null,
+            }),
+          }),
+        }),
+      });
+
+      const result = await checkAdminRole('test-user-id');
+      expect(result).toBe(true);
+    });
+
+    it('should return false when user is not admin', async () => {
+      (supabase.from as any).mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { role: 'user' },
+              error: null,
+            }),
+          }),
+        }),
+      });
+
+      const result = await checkAdminRole('test-user-id');
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/server/middleware/adminCheck.ts
+++ b/server/middleware/adminCheck.ts
@@ -1,0 +1,107 @@
+/**
+ * Admin Role Authorization Middleware
+ *
+ * Validates that the authenticated user has admin privileges.
+ * Must be used after authenticateRequest middleware.
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import { supabase } from '../supabase/client';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * Extended Request interface with auth context
+ */
+export interface AuthenticatedRequest extends Request {
+  auth?: {
+    userId: string;
+    supabaseClient: SupabaseClient;
+  };
+}
+
+/**
+ * Middleware to verify user has admin role
+ *
+ * @throws 401 if user is not authenticated
+ * @throws 403 if user is authenticated but not admin
+ * @throws 500 if database query fails
+ */
+export const requireAdmin = async (
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    // Ensure user is authenticated (should be done by prior middleware)
+    if (!req.auth) {
+      res.status(401).json({
+        success: false,
+        error: 'Unauthorized - Authentication required'
+      });
+      return;
+    }
+
+    // Query user role from database
+    const { data: roleRow, error } = await supabase
+      .from('user_roles')
+      .select('role')
+      .eq('user_id', req.auth.userId)
+      .maybeSingle(); // Use maybeSingle() instead of single() for graceful null handling
+
+    // Handle database errors
+    if (error) {
+      console.error('[Auth] Role check database error:', error);
+      res.status(500).json({
+        success: false,
+        error: 'Failed to verify permissions'
+      });
+      return;
+    }
+
+    // Verify admin role exists and matches
+    if (!roleRow || roleRow.role !== 'admin') {
+      console.warn(`[Auth] Forbidden access attempt by user ${req.auth.userId} - role: ${roleRow?.role || 'none'}`);
+      res.status(403).json({
+        success: false,
+        error: 'Forbidden - Admin role required'
+      });
+      return;
+    }
+
+    // User is admin, proceed to route handler
+    console.info(`[Auth] Admin access granted for user ${req.auth.userId}`);
+    next();
+  } catch (error) {
+    console.error('[Auth] Admin check exception:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Internal server error during authorization'
+    });
+  }
+};
+
+/**
+ * Helper function for programmatic admin checks (non-middleware usage)
+ *
+ * @param userId - The user ID to check
+ * @returns true if user is admin, false otherwise
+ */
+export const checkAdminRole = async (userId: string): Promise<boolean> => {
+  try {
+    const { data: roleRow, error } = await supabase
+      .from('user_roles')
+      .select('role')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (error) {
+      console.error('[Auth] checkAdminRole error:', error);
+      return false;
+    }
+
+    return roleRow?.role === 'admin';
+  } catch (error) {
+    console.error('[Auth] checkAdminRole exception:', error);
+    return false;
+  }
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     include: [
       'src/**/*.{test,spec}.{ts,tsx}',
       'supabase/functions/_shared/**/*.test.ts',
+      'server/**/*.{test,spec}.{ts,tsx}',
     ],
     exclude: ['tests/**', 'node_modules/**'], // tests/** contains Playwright e2e tests only
     // Ensure Node.js built-ins and modules are available for tests
@@ -37,6 +38,7 @@ export default defineConfig({
     environmentVariables: {
       VITE_SUPABASE_URL: 'https://test-project.supabase.co',
       VITE_SUPABASE_ANON_KEY: 'test-anon-key-12345',
+      SUPABASE_SERVICE_ROLE_KEY: 'test-service-role-key-12345',
     },
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
Refactored the admin role check in the push notification test endpoint (`/api/push/test`) into a reusable middleware (`requireAdmin`).

Changes:
1.  **`server/middleware/adminCheck.ts`**: New middleware file containing `requireAdmin` and `checkAdminRole`.
2.  **`server/push/routes.ts`**: Updated `/test` endpoint to use the new middleware chain (`pushLimiter, authMiddleware, requireAdmin`).
3.  **`server/middleware/__tests__/adminCheck.test.ts`**: Added unit tests for the new middleware.
4.  **`vitest.config.ts`**: Configured to run tests in `server/` directory and added `SUPABASE_SERVICE_ROLE_KEY` to environment variables.

This improves maintainability and ensures consistent admin role verification across the backend. Verified with unit tests.

---
*PR created automatically by Jules for task [16529470538431458903](https://jules.google.com/task/16529470538431458903) started by @apexbusiness-systems*